### PR TITLE
Increase chestRewarded second array dimension to larger number.

### DIFF
--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -7,7 +7,7 @@
 #include "z3d/z3DVec.h"
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 8
+#define EXTSAVEDATA_VERSION 9
 #define SAVEFILE_SCENES_DISCOVERED_IDX_COUNT 4
 #define SAVEFILE_SPOILER_ITEM_MAX 512
 
@@ -94,7 +94,7 @@ namespace rnd {
     TingleCollectRegister tingleMaps;
     u32 scenesDiscovered[SAVEFILE_SCENES_DISCOVERED_IDX_COUNT];
     u8 itemCollected[SAVEFILE_SPOILER_ITEM_MAX];
-    u8 chestRewarded[116][30];  // Reward table that's stored by scene and chest param/flag.
+    u8 chestRewarded[116][32];  // Reward table that's stored by scene and chest param/flag.
   } ExtSaveData;
 
   extern "C" ExtSaveData gExtSaveData;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -528,7 +528,10 @@ namespace rnd {
       if (rActiveItemOverride.key.type == ItemOverride_Type::OVR_CHEST) {
         // Check and see if we have trade items or repeatable bottles and add to the array.
         if (rActiveItemRow->itemId < 0x28 || (rActiveItemRow->itemId > 0x30 && rActiveItemRow->itemId < 0x9f)) {
-          gExtSaveData.chestRewarded[rActiveItemOverride.key.scene][rActiveItemOverride.key.flag] = 1;
+          // XXX: Hacky fix but maybe we need to redo how we track chests. Mark Giant's Mask Chest
+          // to be repeatably obtainable since we're not extending this array to 126 in the second dimension.
+          if (rActiveItemOverride.key.flag < 0x20)
+            gExtSaveData.chestRewarded[rActiveItemOverride.key.scene][rActiveItemOverride.key.flag] = 1;
         }
       }
       game::GlobalContext* gctx = rnd::GetContext().gctx;
@@ -566,7 +569,7 @@ namespace rnd {
       ItemOverride_Clear();
       player->get_item_id = incomingGetItemId;
       return;
-    } else if (gExtSaveData.chestRewarded[override.key.scene][override.key.flag] == 1) {
+    } else if (override.key.type == ItemOverride_Type::OVR_CHEST && gExtSaveData.chestRewarded[override.key.scene][override.key.flag] == 1) {
       // Override was already given, use base game's item code
       ItemOverride_Clear();
       player->get_item_id = -(s16)GetItemID::GI_RUPEE_BLUE;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -569,7 +569,8 @@ namespace rnd {
       ItemOverride_Clear();
       player->get_item_id = incomingGetItemId;
       return;
-    } else if (override.key.type == ItemOverride_Type::OVR_CHEST && gExtSaveData.chestRewarded[override.key.scene][override.key.flag] == 1) {
+    } else if (override.key.type == ItemOverride_Type::OVR_CHEST &&
+               gExtSaveData.chestRewarded[override.key.scene][override.key.flag] == 1) {
       // Override was already given, use base game's item code
       ItemOverride_Clear();
       player->get_item_id = -(s16)GetItemID::GI_RUPEE_BLUE;


### PR DESCRIPTION
Check if the item is a chest before giving blue rupee. This avoids items with the same flags but that are collectible instead of being a chest.

Choose not to track Giant's Mask Chest as it's way up there for it's flag.