### PR TITLE
Item fixes

### DIFF
--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -43,8 +43,8 @@ namespace game::act {
     EnHs = 0x0076,
     // Cursed Man Spider House
     EnSsh = 0x0090,
-    // Biggoron
-    EnDai = 0x00D5,
+    // Powder Keg Trial Goron
+    EnGo = 0x00D5,
     // [1] Deku Palace / Woodfall Temple moving platforms (after player lands on them)
     ObjRailLift = 0x00D8,
     // Shooting Gallery - Man

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -71,7 +71,7 @@ namespace rnd {
       BitField<27, 1, u32> enGmGivenItem;
       BitField<28, 1, u32> enFsnANMGivenItem;
       BitField<29, 1, u32> enOshGivenItem;
-      BitField<30, 1, u32> enDaiGivenItem;
+      BitField<30, 1, u32> enGoGivenItem;
       BitField<31, 1, u32> unused;
     };
     GivenItemRegister givenItemChecks;

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -123,9 +123,9 @@ SECTIONS{
     *(.patch_CheckCurrentInventoryOverrideItem)
   }
 
-  .patch_CheckCurrentInventoryOverrideItemTwo 0x201060 : {
+  /* .patch_CheckCurrentInventoryOverrideItemTwo 0x201060 : {
     *(.patch_CheckCurrentInventoryOverrideItemTwo)
-  }
+  } */
 
   /* .patch_OverrideItemIDFour 0x1FBD10 : {
     *(.patch_OverrideItemIdIndex)

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -614,10 +614,10 @@ namespace rnd {
         player->get_item_id = -(s16)GetItemID::GI_BOTTLE_SEAHORSE_REFILL;
         break;
       case 0x70:
-        player->get_item_id = -(s16)GetItemID::GI_BOTTLE_SEAHORSE_REFILL;
+        player->get_item_id = -(s16)GetItemID::GI_BOTTLE_MYSTERY_MILK;
         break;
       default:
-        player->get_item_id = -(s16)GetItemID::GI_BOTTLE_MYSTERY_MILK_REFILL;
+        player->get_item_id = -(s16)GetItemID::GI_RUPEE_BLUE;
         break;
       }
       return;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -44,9 +44,9 @@ namespace rnd {
     rItemOverrides[0].value.getItemId = 0x26;
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6F;
-    rItemOverrides[1].key.type = ItemOverride_Type::OVR_CHEST;
-    rItemOverrides[1].value.getItemId = 0x60;
-    rItemOverrides[1].value.looksLikeItemId = 0x60;
+    rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
+    rItemOverrides[1].value.getItemId = 0x34;
+    rItemOverrides[1].value.looksLikeItemId = 0x34;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;
@@ -730,6 +730,9 @@ namespace rnd {
       return givenItems.enInGivenItem ? (int)currentItem
         : (int)0xFF;
     } else if (currentItem == game::ItemId::PictographBox) {
+      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+        rnd::util::Print("%s: Current item is pictograph and did we give item? %u\n", __func__, (u32)givenItems.enTruGivenItem);	
+      #endif
       return givenItems.enTruGivenItem ? (int)currentItem
         : (int)0xFF;
     } else if (currentItem == game::ItemId::BunnyHood) {
@@ -751,6 +754,9 @@ namespace rnd {
       return givenItems.enFsnANMGivenItem ? (int) currentItem
         : (int)0xFF;
     } else if (currentItem == game::ItemId::PowderKeg) {
+      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+        rnd::util::Print("%s: givenItems.enDaiGivenItem is %u \n", __func__, (u32)givenItems.enDaiGivenItem);	
+      #endif
       return givenItems.enDaiGivenItem ? (int) currentItem
         : (int)0xFF;
     }

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -465,8 +465,8 @@ namespace rnd {
       gExtSaveData.givenItemChecks.enGmGivenItem = 1;
     } else if (storedActorId == game::act::Id::EnOsh) {
       gExtSaveData.givenItemChecks.enOshGivenItem = 1;
-    } else if (storedActorId == game::act::Id::EnDai) {
-      gExtSaveData.givenItemChecks.enDaiGivenItem = 1;
+    } else if (storedGetItemId == rnd::GetItemID::GI_POWDER_KEG) {
+      gExtSaveData.givenItemChecks.enGoGivenItem = 1;
     }
   }
 
@@ -730,9 +730,6 @@ namespace rnd {
       return givenItems.enInGivenItem ? (int)currentItem
         : (int)0xFF;
     } else if (currentItem == game::ItemId::PictographBox) {
-      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        rnd::util::Print("%s: Current item is pictograph and did we give item? %u\n", __func__, (u32)givenItems.enTruGivenItem);	
-      #endif
       return givenItems.enTruGivenItem ? (int)currentItem
         : (int)0xFF;
     } else if (currentItem == game::ItemId::BunnyHood) {
@@ -754,10 +751,18 @@ namespace rnd {
       return givenItems.enFsnANMGivenItem ? (int) currentItem
         : (int)0xFF;
     } else if (currentItem == game::ItemId::PowderKeg) {
-      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        rnd::util::Print("%s: givenItems.enDaiGivenItem is %u \n", __func__, (u32)givenItems.enDaiGivenItem);	
-      #endif
-      return givenItems.enDaiGivenItem ? (int) currentItem
+      // Check scene if we want to buy from goron.
+      auto* gctx = rnd::GetContext().gctx;
+
+      if (gctx->scene == game::SceneId::BombShop) {
+        #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+          rnd::util::Print("%s: Do we have powder keg? Item %u is %u\n", __func__, currentItem, game::HasItem((game::ItemId)currentItem));	
+        #endif
+        return game::HasItem((game::ItemId)currentItem) ? (int) currentItem
+          : (int)0xFF;
+      }
+      
+      return givenItems.enGoGivenItem ? (int) currentItem
         : (int)0xFF;
     }
     auto& inventory = game::GetCommonData().save.inventory.items;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -480,8 +480,8 @@ namespace rnd {
     }
 
     if (gSettingsContext.startingPictographBox > 0) {
-      saveData.inventory.items[13] = game::ItemId::PictographBox;
       rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::PictographBox);
+      saveData.inventory.items[13] = game::ItemId::PictographBox;
     }
 
     if (gSettingsContext.startingGreatFairySword > 0) {

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -43,7 +43,7 @@ namespace rnd {
     saveData.inventory.items[9] = game::ItemId::DekuNuts;
     saveData.inventory.items[10] = game::ItemId::MagicBean;
     // saveData.inventory.items[12] = game::ItemId::PowderKeg;
-    // saveData.inventory.items[13] = game::ItemId::PictographBox;
+    saveData.inventory.items[13] = game::ItemId::PictographBox;
     // saveData.inventory.items[14] = game::ItemId::LensOfTruth;
     saveData.inventory.items[15] = game::ItemId::Hookshot;
     saveData.inventory.items[20] = game::ItemId::LandTitleDeed;
@@ -481,6 +481,7 @@ namespace rnd {
 
     if (gSettingsContext.startingPictographBox > 0) {
       saveData.inventory.items[13] = game::ItemId::PictographBox;
+      rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::PictographBox);
     }
 
     if (gSettingsContext.startingGreatFairySword > 0) {

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -26,7 +26,7 @@ namespace rnd {
     saveData.anonymous_162 = saveData.anonymous_162 | 0x6000;
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::MaskOfTruth);
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::PictographBox);
-    rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::PowderKeg);
+    // rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::PowderKeg);
     // saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
     saveData.inventory.inventory_count_register.bomb_bag_upgrade = game::BombBag::BombBag40;
     saveData.inventory.inventory_count_register.wallet_upgrade = 2;
@@ -42,7 +42,7 @@ namespace rnd {
     saveData.inventory.items[8] = game::ItemId::DekuStick;
     saveData.inventory.items[9] = game::ItemId::DekuNuts;
     saveData.inventory.items[10] = game::ItemId::MagicBean;
-    saveData.inventory.items[12] = game::ItemId::PowderKeg;
+    // saveData.inventory.items[12] = game::ItemId::PowderKeg;
     // saveData.inventory.items[13] = game::ItemId::PictographBox;
     // saveData.inventory.items[14] = game::ItemId::LensOfTruth;
     saveData.inventory.items[15] = game::ItemId::Hookshot;


### PR DESCRIPTION
These item checks now fix the following:
- Pictobox glitching
- Zora mask appearing in items page
- Powder Keg checks now work with logic 
- You can now buy powder kegs from the bomb shop as soon as you acquire them
- Pictograph box now is properly given on save creation if chosen as an option.