### PR TITLE
Fix Twinmold And Various Item Checks

### DIFF
--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -72,7 +72,7 @@ namespace rnd {
       BitField<28, 1, u32> enFsnANMGivenItem;
       BitField<29, 1, u32> enOshGivenItem;
       BitField<30, 1, u32> enGoGivenItem;
-      BitField<31, 1, u32> unused;
+      BitField<31, 1, u32> enBoss02GivenItem;
     };
     GivenItemRegister givenItemChecks;
     union FairyCollectRegister {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -267,6 +267,10 @@ SECTIONS{
     *(.patch_EnteringLocation)
   }
 
+  .patch_TwinmoldRemoveGiantMaskCheck 0x2652D8 : {
+    *(.patch_TwinmoldRemoveGiantMaskCheck)
+  }
+
   /* .patch_TwinmoldConsistentDamage 0x28E544 : {
     *(.patch_TwinmoldConsistentDamage)
   } */

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -127,10 +127,6 @@ SECTIONS{
     *(.patch_CheckCurrentInventoryOverrideItem)
   }
 
-  /* .patch_CheckCurrentInventoryOverrideItemTwo 0x201060 : {
-    *(.patch_CheckCurrentInventoryOverrideItemTwo)
-  } */
-
   /* .patch_OverrideItemIDFour 0x1FBD10 : {
     *(.patch_OverrideItemIdIndex)
   } */
@@ -265,10 +261,6 @@ SECTIONS{
 
   .patch_EnteringLocation 0x23aa54 : {
     *(.patch_EnteringLocation)
-  }
-
-  .patch_TwinmoldRemoveGiantMaskCheck 0x2652D8 : {
-    *(.patch_TwinmoldRemoveGiantMaskCheck)
   }
 
   /* .patch_TwinmoldConsistentDamage 0x28E544 : {

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -105,9 +105,10 @@ hook_SpawnFastElegyStatues:
 
 .global hook_CheckCurrentInventory
 hook_CheckCurrentInventory:
-    push {lr}
+    push {r1-r12, lr}
     bl ItemOverride_CheckInventoryItemOverride
-    pop {pc}
+    pop {r1-r12, lr}
+    b 0x1F3D6C
 
 .global hook_CheckOcarinaDive
 hook_CheckOcarinaDive:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -169,13 +169,6 @@ patch_SpawnFastElegyStatues:
 patch_CheckCurrentInventoryOverrideItem:
     b hook_CheckCurrentInventory
 
-.section .patch_CheckCurrentInventoryOverrideItemTwo
-.global patch_CheckCurrentInventoryOverrideItemTwo
-patch_CheckCurrentInventoryOverrideItemTwo:
-    b hook_CheckCurrentInventory
-
-
-
 .section .patch_ForceSwordUpgradeOnHuman
 .global patch_ForceSwordUpgradeOnHuman
 patch_ForceSwordUpgradeOnHuman:
@@ -288,12 +281,6 @@ OverrideItemID_patch:
 .global patch_EnteringLocation
 patch_EnteringLocation:
     bl hook_EnteringLocation
-
-@ NOP the branch for checking if we have giant's mask and set flag anyway.
-.section .patch_TwinmoldRemoveGiantMaskCheck
-.global patch_TwinmoldRemoveGiantMaskCheck
-patch_TwinmoldRemoveGiantMaskCheck:
-    nop
 
 .section .patch_RemoveGoronMaskCheckDarmani
 .global patch_RemoveGoronMaskCheckDarmani

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -289,6 +289,12 @@ OverrideItemID_patch:
 patch_EnteringLocation:
     bl hook_EnteringLocation
 
+@ NOP the branch for checking if we have giant's mask and set flag anyway.
+.section .patch_TwinmoldRemoveGiantMaskCheck
+.global patch_TwinmoldRemoveGiantMaskCheck
+patch_TwinmoldRemoveGiantMaskCheck:
+    nop
+
 .section .patch_RemoveGoronMaskCheckDarmani
 .global patch_RemoveGoronMaskCheckDarmani
 patch_RemoveGoronMaskCheckDarmani:

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -755,9 +755,6 @@ namespace rnd {
       auto* gctx = rnd::GetContext().gctx;
 
       if (gctx->scene == game::SceneId::BombShop) {
-        #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-          rnd::util::Print("%s: Do we have powder keg? Item %u is %u\n", __func__, currentItem, game::HasItem((game::ItemId)currentItem));	
-        #endif
         return game::HasItem((game::ItemId)currentItem) ? (int) currentItem
           : (int)0xFF;
       }

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -45,8 +45,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6F;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0x34;
-    rItemOverrides[1].value.looksLikeItemId = 0x34;
+    rItemOverrides[1].value.getItemId = 0xA1;
+    rItemOverrides[1].value.looksLikeItemId = 0xA1;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;
@@ -467,6 +467,8 @@ namespace rnd {
       gExtSaveData.givenItemChecks.enOshGivenItem = 1;
     } else if (storedGetItemId == rnd::GetItemID::GI_POWDER_KEG) {
       gExtSaveData.givenItemChecks.enGoGivenItem = 1;
+    } else if ((s16)storedGetItemId == -(s16)rnd::GetItemID::GI_MASK_GIANTS) {
+      gExtSaveData.givenItemChecks.enBoss02GivenItem = 1;
     }
   }
 
@@ -761,9 +763,16 @@ namespace rnd {
       
       return givenItems.enGoGivenItem ? (int) currentItem
         : (int)0xFF;
+    } else if (currentItem == game::ItemId::GiantMask) {
+      return givenItems.enBoss02GivenItem ? (int) currentItem
+        : (int)0xFF;
     }
+    // Use the standard pointer to array as this seems to mess with
+    // some issues in checking items such as trade items, and Giant's Mask.
     auto& inventory = game::GetCommonData().save.inventory.items;
-    return (int)inventory[(int)currentItem];
+    u8* slotArray = (u8*)0x626cdc;
+    u8 slot = slotArray[(int)currentItem];
+    return (int)inventory[slot];
   }
 
   // clang-format on

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -212,7 +212,7 @@ namespace rnd {
     saveData.meeting_happy_mask_salesman_0x01 = 0x01;
     saveData.skullkid_backstory_cutscene_0x10 = 0x10;
     saveData.cut_scene_flag_bundle.owl_statue_cut_scene = 1;
-    saveData.dungeon_skip_portal_cutscene_0x3C_to_skip_all = 0x3C;
+    // saveData.dungeon_skip_portal_cutscene_0x3C_to_skip_all = 0x3C;
     saveData.turtle_flags.skip_swimming_to_great_bay_temple_cutscene = 1;
 
     // Needs to be greater than zero to skip first time song of time cutscene


### PR DESCRIPTION
This PR now includes a change to how items are viewed in game, and should allow Red twinmold to spawn, Room Key to be able to get into the Knife Room, etc.