### PR TITLE
Cycle Reset Fixes On Temples

### DIFF
--- a/code/include/game/context.h
+++ b/code/include/game/context.h
@@ -468,6 +468,15 @@ namespace game {
   static_assert(offsetof(GlobalContext, gap_8384) == 0x8384);
   static_assert(sizeof(GlobalContext) == 0x11030);
 
+  struct PersistentSceneCycleFlags {
+    u32 switch0;
+    u32 switch1;
+    u32 chest;
+    u32 collectible;
+  };
+  static_assert(sizeof(PersistentSceneCycleFlags) == 0x10);
+
+  PersistentSceneCycleFlags* GetPersistentCycleStruct();
 }  // namespace game
 
 #endif

--- a/code/include/rnd/custom_entrances.h
+++ b/code/include/rnd/custom_entrances.h
@@ -14,7 +14,10 @@ extern "C" {
 #endif
 
 namespace rnd {
-  extern "C" bool SceneEntranceOverride();
+  extern "C" {
+    bool SceneEntranceOverride();
+    bool IsTempleScene(int);
+  }
 }  // namespace rnd
 
 #endif

--- a/code/include/rnd/custom_entrances.h
+++ b/code/include/rnd/custom_entrances.h
@@ -15,8 +15,8 @@ extern "C" {
 
 namespace rnd {
   extern "C" {
-    bool SceneEntranceOverride();
-    bool IsTempleScene(int);
+  bool SceneEntranceOverride();
+  void ForceTempleFlags();
   }
 }  // namespace rnd
 

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -63,21 +63,9 @@ SECTIONS{
     *(.patch_RemoveMysteryMilkTimer)
   }
 
-  /* .patch_TempleAsLastScence 0x1C9310 : {
-    *(.patch_TempleAsLastScence)
-  }*/
-
-  .patch_DoNotResetTempleFlags 0x1c936c : {
-  *(.patch_AttemptKeepChestsClosed)
+  .patch_DoNotResetTempleFlags 0x1C936C : {
+    *(.patch_DoNotResetTempleFlags)
   } 
-
-   /* .patch_tmp 0x545a30 : {
-    *(.patch_tmp)
-  } */
-
-  /*.patch_tmp2 0x1c93cc : {
-    *(.patch_tmp2)
-  } */
 
   .patch_DoNotRemoveKeys 0x1C9B94 : {
     *(.patch_DoNotRemoveKeys)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -63,8 +63,20 @@ SECTIONS{
     *(.patch_RemoveMysteryMilkTimer)
   }
 
-  /* .patch_AttemptKeepChestsClosed 0x1c9300 : {
+  /* .patch_TempleAsLastScence 0x1C9310 : {
+    *(.patch_TempleAsLastScence)
+  }*/
+
+  .patch_DoNotResetTempleFlags 0x1c936c : {
   *(.patch_AttemptKeepChestsClosed)
+  } 
+
+   /* .patch_tmp 0x545a30 : {
+    *(.patch_tmp)
+  } */
+
+  /*.patch_tmp2 0x1c93cc : {
+    *(.patch_tmp2)
   } */
 
   .patch_DoNotRemoveKeys 0x1C9B94 : {

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -71,6 +71,57 @@ doNotOverrideCutscene:
     bl 0x22A7F8
     b 0x1B1838
 
+.global hook_TempleAsLastScene
+hook_TempleAsLastScene:
+    push {r0-r12, lr}
+    bl IsTempleScene
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    beq 0x1C936C
+    @ original instruction.
+    push {lr}
+    bl 0x190A54
+    pop {lr}
+    bx lr
+
+.global hook_DebugHook
+hook_DebugHook:
+    push {r0-r12,lr}
+    mov r5, r0
+    bl printR1
+    pop {r0-r12,lr}
+    str r2, [r1], #20
+    bx lr
+
+.global hook_DoNotResetFlagsGeneric
+hook_DoNotResetFlagsGeneric:
+    push {r0-r12, lr}
+    bl IsTempleScene
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    beq templeCaseGeneric
+    @beq 0x1C93C8
+    add r0,r0,#0x1
+    bx lr
+templeCaseGeneric:
+    add r0,r0,#0x1
+    add r0,r0,#0x1
+    bx lr
+
+.global hook_DoNotResetTempleFlags
+hook_DoNotResetTempleFlags:
+    mov r0, #0x0
+    push {r0-r12, lr}
+    bl IsTempleScene
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    bne templeCase
+    @beq 0x1C93C8
+    b 0x1C9370
+templeCase:
+    add r0,r0,#0x1
+    b 0x1C9370
+
 .global hook_ChangeSOHToCustomText
 hook_ChangeSOHToCustomText:
     push {r0-r2, lr}

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -71,56 +71,13 @@ doNotOverrideCutscene:
     bl 0x22A7F8
     b 0x1B1838
 
-.global hook_TempleAsLastScene
-hook_TempleAsLastScene:
-    push {r0-r12, lr}
-    bl IsTempleScene
-    cmp r0,#0x1
-    pop {r0-r12, lr}
-    beq 0x1C936C
-    @ original instruction.
-    push {lr}
-    bl 0x190A54
-    pop {lr}
-    bx lr
-
-.global hook_DebugHook
-hook_DebugHook:
-    push {r0-r12,lr}
-    mov r5, r0
-    bl printR1
-    pop {r0-r12,lr}
-    str r2, [r1], #20
-    bx lr
-
-.global hook_DoNotResetFlagsGeneric
-hook_DoNotResetFlagsGeneric:
-    push {r0-r12, lr}
-    bl IsTempleScene
-    cmp r0,#0x1
-    pop {r0-r12, lr}
-    beq templeCaseGeneric
-    @beq 0x1C93C8
-    add r0,r0,#0x1
-    bx lr
-templeCaseGeneric:
-    add r0,r0,#0x1
-    add r0,r0,#0x1
-    bx lr
-
 .global hook_DoNotResetTempleFlags
 hook_DoNotResetTempleFlags:
-    mov r0, #0x0
     push {r0-r12, lr}
-    bl IsTempleScene
-    cmp r0,#0x1
+    bl ForceTempleFlags
     pop {r0-r12, lr}
-    bne templeCase
-    @beq 0x1C93C8
-    b 0x1C9370
-templeCase:
-    add r0,r0,#0x1
-    b 0x1C9370
+    mov r0,#0x0
+    bx lr
 
 .global hook_ChangeSOHToCustomText
 hook_ChangeSOHToCustomText:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -95,16 +95,34 @@ patch_OverrideCutsceneNextEntrance:
 patch_RemoveMysteryMilkTimer:
     nop
 
-@ Skip past all chest content resetting.
-@ Since this is rando, we don't want users
-@ getting chests again, and instead of
-@ keeping track via extdata we can just 
-@ branch over everything in relation to 
-@ resetting all the chests in the game.
-.section .patch_AttemptKeepChestsClosed
-.global patch_AttemptKeepChestsClosed
-patch_AttemptKeepChestsClosed:
-    b 0x01c936c
+@ There's a check on gctx->scene here that we 
+@ should ignore if we are a temple to avoid
+@ resetting any doors.
+.section .patch_TempleAsLastScence
+.global patch_TempleAsLastScence
+patch_TempleAsLastScence:
+    @bl hook_TempleAsLastScene
+
+@ Skip past all the fairy and 
+@ door resetting if we are the temples
+@ as we don't want to softlock users
+@ if they have already used their keys.
+.section .patch_DoNotResetTempleFlags
+.global patch_DoNotResetTempleFlags
+patch_DoNotResetTempleFlags:
+    b hook_DoNotResetTempleFlags
+
+.section .patch_tmp
+.global patch_tmp
+patch_tmp:
+    bl hook_DoNotResetFlagsGeneric
+
+.section .patch_tmp2
+.global patch_tmp2
+patch_tmp2:
+    nop
+    cmp r0,#0x75
+    nop
 
 @ Skips past a loop that resets all
 @ values in the each dungeon for 

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -95,14 +95,6 @@ patch_OverrideCutsceneNextEntrance:
 patch_RemoveMysteryMilkTimer:
     nop
 
-@ There's a check on gctx->scene here that we 
-@ should ignore if we are a temple to avoid
-@ resetting any doors.
-.section .patch_TempleAsLastScence
-.global patch_TempleAsLastScence
-patch_TempleAsLastScence:
-    @bl hook_TempleAsLastScene
-
 @ Skip past all the fairy and 
 @ door resetting if we are the temples
 @ as we don't want to softlock users
@@ -110,19 +102,7 @@ patch_TempleAsLastScence:
 .section .patch_DoNotResetTempleFlags
 .global patch_DoNotResetTempleFlags
 patch_DoNotResetTempleFlags:
-    b hook_DoNotResetTempleFlags
-
-.section .patch_tmp
-.global patch_tmp
-patch_tmp:
-    bl hook_DoNotResetFlagsGeneric
-
-.section .patch_tmp2
-.global patch_tmp2
-patch_tmp2:
-    nop
-    cmp r0,#0x75
-    nop
+    bl hook_DoNotResetTempleFlags
 
 @ Skips past a loop that resets all
 @ values in the each dungeon for 

--- a/code/source/game/context.cpp
+++ b/code/source/game/context.cpp
@@ -65,4 +65,9 @@ namespace game {
     rnd::util::GetPointer<void(GlobalContext*)>(0x230ec8)(this);
   }
 
+  // Grabs the persistent cycle flags for cycle reset.
+  PersistentSceneCycleFlags* GetPersistentCycleStruct() {
+    return rnd::util::GetPointer<PersistentSceneCycleFlags>(0x6A017C);
+  }
+
 }  // namespace game

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -1,7 +1,8 @@
 #include "rnd/custom_entrances.h"
 
 namespace rnd {
-  extern "C" bool SceneEntranceOverride() {
+  extern "C" {
+  bool SceneEntranceOverride() {
     game::CommonData& cdata = game::GetCommonData();
     game::GlobalContext* gctx = GetContext().gctx;
     bool didWarp = false;
@@ -36,4 +37,27 @@ namespace rnd {
       gctx->field_C529_one_to_clear_input = 0x14;
     return didWarp;
   }
+
+  bool IsTempleScene(int scene) {
+
+    if (scene == (int)game::SceneId::Woodfall || scene == (int)game::SceneId::SnowheadTemple ||
+        scene == (int)game::SceneId::GreatBayTemple || scene == (int)game::SceneId::StoneTowerTemple ||
+        scene == (int)game::SceneId::StoneTowerTempleInverted) {
+          #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+            rnd::util::Print("%s: We are a temple scene! ID is %#04x returning true %u\n", __func__, (s16)scene, true);	
+          #endif
+          return true;
+        }
+      
+    else
+      return false;
+  }
+
+  void printR1(int scene) {
+    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+            rnd::util::Print("%s: We are a temple scene! ID is %s\n", __func__, (s16)scene);	
+          #endif
+  }
+  }
+
 }  // namespace rnd

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -38,25 +38,13 @@ namespace rnd {
     return didWarp;
   }
 
-  bool IsTempleScene(int scene) {
-
-    if (scene == (int)game::SceneId::Woodfall || scene == (int)game::SceneId::SnowheadTemple ||
-        scene == (int)game::SceneId::GreatBayTemple || scene == (int)game::SceneId::StoneTowerTemple ||
-        scene == (int)game::SceneId::StoneTowerTempleInverted) {
-          #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-            rnd::util::Print("%s: We are a temple scene! ID is %#04x returning true %u\n", __func__, (s16)scene, true);	
-          #endif
-          return true;
-        }
-      
-    else
-      return false;
-  }
-
-  void printR1(int scene) {
-    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-            rnd::util::Print("%s: We are a temple scene! ID is %s\n", __func__, (s16)scene);	
-          #endif
+  void ForceTempleFlags() {
+    game::PersistentSceneCycleFlags* cycleFlags = game::GetPersistentCycleStruct();
+    cycleFlags[(u32)game::SceneId::WoodfallTemple].switch1 = 0xFFFFFFFF;
+    cycleFlags[(u32)game::SceneId::SnowheadTemple].switch1 = 0xFFFFFFFF;
+    cycleFlags[(u32)game::SceneId::GreatBayTemple].switch1 = 0xFFFFFFFF;
+    cycleFlags[(u32)game::SceneId::StoneTowerTemple].switch1 = 0xFFFFFFFF;
+    cycleFlags[(u32)game::SceneId::StoneTowerTempleInverted].switch1 = 0xFFFFFFFF;
   }
   }
 

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -372,10 +372,10 @@ namespace rnd {
       // give starting spirit keys for vanilla key locations
     } else {
       // Init to 0 as the game inits to 255.
-      saveData.inventory.woodfall_temple_keys = 0;
-      saveData.inventory.snowhead_temple_keys = 0;
-      saveData.inventory.great_bay_temple_keys = 0;
-      saveData.inventory.stone_tower_temple_keys = 0;
+      // saveData.inventory.woodfall_temple_keys = 0;
+      // saveData.inventory.snowhead_temple_keys = 0;
+      // saveData.inventory.great_bay_temple_keys = 0;
+      // saveData.inventory.stone_tower_temple_keys = 0;
     }
 
     // give boss keys


### PR DESCRIPTION
This patch should now allow us to keep doors open, and remove stray fairies from spawning that were previously free standing.