### PR TITLE
Fix Swamp Manager to no longer give repeating items

### DIFF
--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -70,7 +70,7 @@ namespace game::act {
     // Npc For Curiosity Shop Owner
     NpcEnFsn = 0x0157,
     // Npc For Boat Photography
-    NpcSwampPhotographer = 0x0158,
+    EnShn = 0x0158,
     // NPC Postman
     NpcEnPm = 0x0166,
     // Goht

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -7,7 +7,7 @@
 #include "z3d/z3DVec.h"
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 11
+#define EXTSAVEDATA_VERSION 12
 #define SAVEFILE_SCENES_DISCOVERED_IDX_COUNT 4
 #define SAVEFILE_SPOILER_ITEM_MAX 512
 
@@ -74,7 +74,8 @@ namespace rnd {
       BitField<30, 1, u64> enGoGivenItem;
       BitField<31, 1, u64> enBoss02GivenItem;
       BitField<32, 1, u64> enGinkoManGivenItem;
-      BitField<33, 31, u64> unused;
+      BitField<33, 31, u64> enShnGivenItem;
+      BitField<34, 30, u64> unused;
     };
     GivenItemRegister givenItemChecks;
     union FairyCollectRegister {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -396,8 +396,11 @@ namespace rnd {
       }
     } else if (actorId == game::act::Id::NpcEnBjt) {
       getItemId = incomingNegative ? -0x01 : 0x01;
-    } else if (actorId == game::act::Id::NpcSwampPhotographer) {
-      getItemId = incomingNegative ? -0xBA : 0xBA;
+    } else if (actorId == game::act::Id::EnShn) {
+      if (gExtSaveData.givenItemChecks.enShnGivenItem == 1)
+        getItemId = incomingNegative ? -0x02 : 0x02;
+      else
+        getItemId = incomingNegative ? -0xBA : 0xBA;
     } else if (actorId == game::act::Id::NpcInvisibleGuard) {
       if (gExtSaveData.givenItemChecks.enStoneHeishiGivenItem > 0) {
         getItemId = incomingNegative ? -0xBA : 0xBA;
@@ -478,6 +481,8 @@ namespace rnd {
         saveData.anonymous_117 = saveData.anonymous_117 | 8;
         gExtSaveData.givenItemChecks.enGinkoManGivenItem = 2;
       }
+    } else if (storedActorId == game::act::Id::EnShn) {
+      gExtSaveData.givenItemChecks.enShnGivenItem = 1;
     }
   }
 


### PR DESCRIPTION
 Opt to fishing passes instead, because that's default behaviour.