### PR TITLE
Fix Small Keys Not Initializing Again

### DIFF
--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -63,17 +63,26 @@ namespace rnd {
   }
 
   void ItemEffect_GiveSmallKey(game::CommonData* comData, s16 dungeonId, s16 arg2) {
+    // Have the checks in here as a safety measure in case save file doesn't write them.
     switch (dungeonId) {
     case 0:
+      if (comData->save.inventory.woodfall_temple_keys == 255)
+        comData->save.inventory.woodfall_temple_keys = 0;
       comData->save.inventory.woodfall_temple_keys = comData->save.inventory.woodfall_temple_keys + 1;
       break;
     case 1:
+      if (comData->save.inventory.snowhead_temple_keys == 255)
+        comData->save.inventory.snowhead_temple_keys = 0;
       comData->save.inventory.snowhead_temple_keys = comData->save.inventory.snowhead_temple_keys + 1;
       break;
     case 2:
+      if (comData->save.inventory.great_bay_temple_keys == 255)
+        comData->save.inventory.great_bay_temple_keys = 0;
       comData->save.inventory.great_bay_temple_keys = comData->save.inventory.great_bay_temple_keys + 1;
       break;
     case 3:
+      if (comData->save.inventory.stone_tower_temple_keys == 255)
+        comData->save.inventory.stone_tower_temple_keys = 0;
       comData->save.inventory.stone_tower_temple_keys = comData->save.inventory.stone_tower_temple_keys + 1;
       break;
     default:

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -45,8 +45,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6F;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0x49;
-    rItemOverrides[1].value.looksLikeItemId = 0x49;
+    rItemOverrides[1].value.getItemId = 0x76;
+    rItemOverrides[1].value.looksLikeItemId = 0x76;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -58,10 +58,6 @@ namespace rnd {
     saveData.inventory.masks[20] = game::ItemId::GaroMask;
     saveData.inventory.masks[6] = game::ItemId::AllNightMask;
 
-    saveData.inventory.woodfall_temple_keys = 8;
-    saveData.inventory.snowhead_temple_keys = 8;
-    saveData.inventory.great_bay_temple_keys = 8;
-    saveData.inventory.stone_tower_temple_keys = 8;
     saveData.inventory.woodfall_dungeon_items.map = 1;
     saveData.inventory.woodfall_dungeon_items.compass = 1;
     saveData.inventory.woodfall_dungeon_items.boss_key = 1;
@@ -372,10 +368,16 @@ namespace rnd {
       // give starting spirit keys for vanilla key locations
     } else {
       // Init to 0 as the game inits to 255.
-      // saveData.inventory.woodfall_temple_keys = 0;
-      // saveData.inventory.snowhead_temple_keys = 0;
-      // saveData.inventory.great_bay_temple_keys = 0;
-      // saveData.inventory.stone_tower_temple_keys = 0;
+      saveData.inventory.woodfall_temple_keys = 0;
+      saveData.inventory.snowhead_temple_keys = 0;
+      saveData.inventory.great_bay_temple_keys = 0;
+      saveData.inventory.stone_tower_temple_keys = 0;
+#ifdef ENABLE_DEBUG
+      saveData.inventory.woodfall_temple_keys = 8;
+      saveData.inventory.snowhead_temple_keys = 8;
+      saveData.inventory.great_bay_temple_keys = 8;
+      saveData.inventory.stone_tower_temple_keys = 8;
+#endif
     }
 
     // give boss keys


### PR DESCRIPTION
Put back the key sets to 0 in savefile to prevent keys from being initialized to 255.
In case that fails, include a check in the item effect of small keys to ensure we initialize them properly.