### PR TITLE
Set Keaton's get item to an unused rupee 10 item

### DIFF
--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -414,7 +414,7 @@ namespace rnd {
     } else if (getItemId == static_cast<s16>(rnd::GetItemID::GI_MASK_CAPTAINS_HAT)) {
       gExtSaveData.givenItemChecks.enOskGivenItem = 1;
     } else if (actorId == game::act::Id::EnKitan) {
-      getItemId = incomingNegative ? -0x01 : 0x01;
+      getItemId = incomingNegative ? -0x03 : 0x03;
     }
 
     return getItemId;


### PR DESCRIPTION
This will prevent overrides with postbox secondary get items after retrieving the first item.