### PR TITLE
Trade item swaps

### DIFF
--- a/code/Makefile
+++ b/code/Makefile
@@ -33,7 +33,7 @@ include $(DEVKITARM)/3ds_rules
 #---------------------------------------------------------------------------------
 TARGET		:=	$(notdir $(CURDIR))
 BUILD		:=	build
-SOURCES		:=	source source/asm source/lib source/common source/game source/rnd
+SOURCES		:=	source source/asm source/lib source/common source/game source/rnd source/game/ui/screens
 DATA		:=	data
 INCLUDES	:=	include
 GRAPHICS	:=	gfx

--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -325,14 +325,14 @@ namespace game::act {
 
   // Name courtesy of the OoT decomp project.
   struct DynaPolyActor : Actor {
-    u32 dyna_poly_id;
-    float field_1FC;
+    u32 bg_id;
+    float push_force;
     float field_200;
-    u16 field_204;
-    u8 field_206;
-    u32 dyna_poly_flags;
+    s16 y_rotation;
+    u32 transform_flags;
+    u8 interact_flags;
   };
-  static_assert(sizeof(DynaPolyActor) == 0x20C);
+  static_assert(sizeof(DynaPolyActor) == 0x210);
 
   struct DayTimerActor {
     Actor common_actor;

--- a/code/include/game/actors/chest.h
+++ b/code/include/game/actors/chest.h
@@ -1,0 +1,55 @@
+#ifndef _GAME_ACTORS_CHEST_H
+#define _GAME_ACTORS_CHEST_H
+
+#include "game/actor.h"
+#include "game/as.h"
+#include "game/collision.h"
+#include "game/skelanime.h"
+#include "rnd/item_override.h"
+
+namespace game::actors {
+  enum class EnBoxType : u8 {
+    ENBOX_TYPE_BIG = 0,  // E.g. Hookshot Chest
+    ENBOX_TYPE_BIG_ROOM_CLEAR = 1,
+    ENBOX_TYPE_BIG_ORNATE = 2,  // E.g. Boss Key Chests
+    ENBOX_TYPE_BIG_SWITCH_FLAG_FALL = 3,
+    ENBOX_TYPE_BIG_INVISIBLE = 4,
+    ENBOX_TYPE_SMALL = 5,
+    ENBOX_TYPE_SMALL_INVISIBLE = 6,
+    ENBOX_TYPE_SMALL_ROOM_CLEAR = 7,
+    ENBOX_TYPE_SMALL_SWITCH_FLAG_FALL = 8,
+    ENBOX_TYPE_BIG_SONG_ZELDAS_LULLABY = 9,
+    ENBOX_TYPE_BIG_SONG_SUNS = 10,
+    ENBOX_TYPE_BIG_SWITCH_FLAG = 11,
+    ENBOX_TYPE_SMALL_SWITCH_FLAG = 12
+  };
+
+  struct En_Box {
+    game::act::DynaPolyActor dyna;
+    SkelAnime* skel_anime;
+    u8 gap_210[52];
+    CollisionInfoCylinder* collision_cylinder;
+    u8 gap_248[84];
+    int field_29C;
+    u8 gap_2A0[8];
+    void* some_fn;
+    u8 gap_2AC[312];
+    u16 some_item_check;
+    u8 movement_flags;
+    u8 alpha;
+    u8 switch_flag;
+    EnBoxType chest_type;
+    u8 iceSmokeTImer;
+    s8 field_3EB;
+    u8 gap_3EC[16];
+    void* field_3fc;
+    u8 gap_400[16];
+    game::act::Actor* field_410;
+    int csId2;
+    rnd::GetItemID GetItemID;
+    s32 collectableFlag;
+    u8 gap_420[8];
+  };
+}  // namespace game::actors
+
+#endif

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -49,7 +49,7 @@ namespace game {
   struct PlayerData {
     char field_11C[4];
     u8 gap_124[2];
-    u16 song_of_time_counter;  // Plays song of time cutscene when == 0
+    u16 three_day_reset_count;  // Plays song of time cutscene when == 0
     char16_t playerName[8];
     u16 anonymous_h;
 
@@ -316,7 +316,7 @@ namespace game {
     int previous_defeated_boss;  // or last viewed giant cutscene, values 4 and greater makes
                                  // woodfall giant repeat for all temples.
     // u8 gap1221[3];
-    int anonymous_63;
+    int stolenItems;
     u8 gap1220[8];
     u16 bank_rupee_count;
     u16 anonymous_64;

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -226,13 +226,13 @@ namespace game {
     /// In-game time.
     /// 0x0000 is midnight, 0x4000 is 6am, 0x8000 is noon, 0xc000 is 6pm.
     u16 time;
-    u16 anonymous_3;
+    u16 jinxTimer;
     u16 rupee_accumulator;
     act::Player::Form player_form;
     char anonymous_5;
     bool has_tatl;
     char anonymous_7;
-    char anonymous_8;
+    char bButtonUsability;
     char anonymous_9;
     char anonymous_10;
     char anonymous_11;

--- a/code/include/game/player.h
+++ b/code/include/game/player.h
@@ -416,7 +416,8 @@ namespace game::act {
     u8 gap_11EC0[6];
     char field_11EC6;
     char field_11EC7;
-    u16 disable_b_if_255;
+    // u8 field_11EC8;
+    u16 blastMaskTimer;
     u16 zora_barrier_timer;
     u16 field_11ECC;
     char field_11ECE[1];

--- a/code/include/game/skelanime.h
+++ b/code/include/game/skelanime.h
@@ -1,0 +1,39 @@
+#ifndef _GAME_SKELANIME_H
+#define _GAME_SKELANIME_H
+
+#include "common/types.h"
+#include "game/context.h"
+#include "z3d/z3DVec.h"
+
+namespace game {
+
+  struct SkelAnime {
+    u8 limb_count;
+    u8 mode;
+    u8 d_list_count;
+    s8 taper;
+    void** skeleton; /*  An array of pointers to limbs. Can be StandardLimb, LodLimb, or SkinLimb. */
+    void* animation; /* Can be an AnimationHeader or PlayerAnimationHeader. */
+    float start_frame;
+    float end_frame;
+    float animation_length;
+    float cur_frame;
+    float play_speed;
+    z3dVec3s* joint_table;
+    z3dVec3s* morph_table;
+    float morph_weight;
+    float morph_rate;
+    union {
+      s32 (*normal)(struct SkelAnime*);  // Can be Loop, Partial loop, Play once, Morph, or Tapered morph
+      s32 (*player)(struct game::GlobalContext*, struct SkelAnime*);  // Loop, Play once, and Morph
+    } update;
+    s8 init_flags;
+    u8 move_flags;
+    s16 prev_yaw;
+    z3dVec3s prev_transl;
+    z3dVec3s base_transl;
+  };
+
+}  // namespace game
+
+#endif

--- a/code/include/game/ui.h
+++ b/code/include/game/ui.h
@@ -438,6 +438,33 @@ namespace game::ui {
   };
   static_assert(sizeof(Layout) == 0x170);
 
+  struct ItemIcon {
+    Layout thisx;
+    u8 initialized;
+    u8 gap_171[3];
+    int icon_id;
+    int item_count;
+    int icon_number;
+    int rank_ten;
+    AnimPlayer* item_icon_player;
+    AnimPlayer* rank_ten_player;
+    AnimPlayer* rank_a_player;
+    AnimPlayer* color_player;
+    AnimPlayer* main_player;
+    Anim* idle_anim;
+    Anim* pressed_anim;
+    Anim* activated_anim;
+    Anim* disabled_anim;
+    Anim* unusable_anim;
+    Anim* selected_anim;
+    AnimPlayer* return_player;
+    Anim* return_to_start_anim;
+    Anim* return_vanish_idle_anim;
+    Anim* return_remain_idle_anim;
+    Anim* return_empty_idle_anim;
+    Anim* equip_anim;
+    void* item_icon_pane;
+  };
   struct CommonLayouts {
     Layout* touch_panel;
     Layout* background;

--- a/code/include/game/ui/screens/gearscreen.h
+++ b/code/include/game/ui/screens/gearscreen.h
@@ -1,0 +1,69 @@
+#include "common/utils.h"
+#include "game/message.h"
+#include "game/ui.h"
+
+#ifndef _GAME_UI_GEARSCREEN_H
+#define _GAME_UI_GEARSCREEN_H
+
+namespace game::ui::screens {
+  struct GearScreen {
+    Screen* screen;
+    int press_handler;
+    u16 field_8;
+    u16 field_A;
+    void* subMenuTitle;
+    void* subMenuUpCollect;
+    void* menuCollect;
+    void* commonBottomBg;
+    void* btn_return_top_l;
+    void* btn_return;
+    void* btn_option_l;
+    void* main_player;
+    void* in_menu_collect_anim;
+    void* out_menu_collect_anim;
+    u8 gap_34[240];
+    int field_124;
+    int field_128;
+    int field_12C;
+    ItemIcon* cursorItemCollect;
+    ItemIcon* icon_event00_l;
+    ItemIcon* icon_event01_l;
+    ItemIcon* icon_event02_l;
+    ItemIcon* icon_event03_l;
+    ItemIcon* icon_shadowgraph_box_l;
+    ItemIcon* icon_purse_l;
+    ItemIcon* icon_bomb_bag_l;
+    ItemIcon* icon_arrow_l;
+    ItemIcon* icon_sword_l;
+    ItemIcon* icon_shield_l;
+    ItemIcon* icon_boss00_l;
+    ItemIcon* icon_boss02_l;
+    ItemIcon* icon_boss01_l;
+    ItemIcon* icon_boss03_l;
+    ItemIcon* icon_schedule_l;
+    ItemIcon* icon_okarina_l;
+    ItemIcon* icon_trumpet_l;
+    ItemIcon* icon_drum_l;
+    ItemIcon* icon_guitar_l;
+    ItemIcon* icon_f_tickets_l;
+    ItemIcon* heart_pieces_l;
+    void* frame_deformation_player;
+    void* blink_picture_g;
+    void* small_picture_g;
+    u8 field_194;
+    u8 cursorIndex;  // Possible Index For Selected Item on Gear Screen
+    u8 field_196;
+    u8 field_197;
+    int pressed_btn_option;
+    int field_19C;
+    int field_1A0;
+    u8 has_opened_option_menu;
+    u8 gap_1a5[3];
+  };
+  static_assert(sizeof(GearScreen) == 0x1A8);
+  static_assert(offsetof(GearScreen, press_handler) == 0x00004);
+
+  GearScreen* GetGearScreen();
+}  // namespace game::ui::screens
+
+#endif

--- a/code/include/rnd/chest.h
+++ b/code/include/rnd/chest.h
@@ -30,7 +30,7 @@ namespace rnd {
     DECORATED_SMALL,
   };
 
-  extern "C" game::actors::EnBoxType Chest_OverrideTexture(game::actors::En_Box*, game::GlobalContext*, s16);
+  extern "C" game::actors::EnBoxType Chest_OverrideSize(game::actors::En_Box*, game::GlobalContext*, s16);
   // void EnBox_rInit(game::act::Actor* thisx, game::GlobalContext* globalCtx);
   // void EnBox_rUpdate(game::act::Actor* thisx, game::GlobalContext* globalCtx);
   // u8 Chest_OverrideAnimation();

--- a/code/include/rnd/chest.h
+++ b/code/include/rnd/chest.h
@@ -2,8 +2,16 @@
 #define _RND_CHEST_H_
 
 #include "common/advanced_context.h"
+#include "game/actors/chest.h"
 #include "game/context.h"
-
+#include "rnd/item_override.h"
+#include "rnd/settings.h"
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#include "common/debug.h"
+extern "C" {
+#include <3ds/svc.h>
+}
+#endif
 namespace rnd {
   enum class ChestSize : u8 {
     VANILLA_SIZE,
@@ -22,10 +30,11 @@ namespace rnd {
     DECORATED_SMALL,
   };
 
-  void EnBox_rInit(game::act::Actor* thisx, game::GlobalContext* globalCtx);
-  void EnBox_rUpdate(game::act::Actor* thisx, game::GlobalContext* globalCtx);
-  u8 Chest_OverrideAnimation();
-  u8 Chest_OverrideDecoration();
-  u8 Chest_OverrideIceSmoke(game::act::Actor* thisx);
+  extern "C" game::actors::EnBoxType Chest_OverrideTexture(game::actors::En_Box*, game::GlobalContext*, s16);
+  // void EnBox_rInit(game::act::Actor* thisx, game::GlobalContext* globalCtx);
+  // void EnBox_rUpdate(game::act::Actor* thisx, game::GlobalContext* globalCtx);
+  // u8 Chest_OverrideAnimation();
+  // u8 Chest_OverrideDecoration();
+  // u8 Chest_OverrideIceSmoke(game::act::Actor* thisx);
 }  // namespace rnd
 #endif  //_CHEST_H_

--- a/code/include/rnd/custom_screen.h
+++ b/code/include/rnd/custom_screen.h
@@ -16,7 +16,8 @@ namespace rnd {
   namespace gearscreen {
     extern "C" void GearScreen_GetStoredTradeItem(game::ui::screens::GearScreen*);
     void GearScreen_DrawAndShowItem(game::ItemId, game::ui::Anim*, u16, int);
-    bool GearScreen_LoopDeedsForward(game::ui::screens::GearScreen*, int, game::ItemId);
+    bool GearScreen_LoopTradeItemsForward(game::ui::screens::GearScreen*, int, game::ItemId);
+    bool GearScreen_LoopTradeItemsBackward(game::ui::screens::GearScreen*, int, game::ItemId);
     int GearScreen_GetTextIdFromItemId(game::ItemId);
     int GearScreen_GetModelIdFromItemId(game::ItemId);
   }  // namespace gearscreen

--- a/code/include/rnd/custom_screen.h
+++ b/code/include/rnd/custom_screen.h
@@ -1,0 +1,25 @@
+#ifndef _RND_CUSTOM_SCREEN_H_
+#define _RND_CUSTOM_SCREEN_H_
+
+#include "common/advanced_context.h"
+#include "common/types.h"
+#include "game/ui/screens/gearscreen.h"
+#include "rnd/savefile.h"
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#include "common/debug.h"
+extern "C" {
+#include <3ds/svc.h>
+}
+#endif
+
+namespace rnd {
+  namespace gearscreen {
+    extern "C" void GearScreen_GetStoredTradeItem(game::ui::screens::GearScreen*);
+    void GearScreen_DrawAndShowItem(game::ItemId, game::ui::Anim*, u16, int);
+    bool GearScreen_LoopDeedsForward(game::ui::screens::GearScreen*, int, game::ItemId);
+    int GearScreen_GetTextIdFromItemId(game::ItemId);
+    int GearScreen_GetModelIdFromItemId(game::ItemId);
+  }  // namespace gearscreen
+}  // namespace rnd
+
+#endif

--- a/code/include/rnd/custom_screen.h
+++ b/code/include/rnd/custom_screen.h
@@ -16,8 +16,8 @@ namespace rnd {
   namespace gearscreen {
     extern "C" void GearScreen_GetStoredTradeItem(game::ui::screens::GearScreen*);
     void GearScreen_DrawAndShowItem(game::ItemId, game::ui::Anim*, u16, int);
-    bool GearScreen_LoopTradeItemsForward(game::ui::screens::GearScreen*, int, game::ItemId);
-    bool GearScreen_LoopTradeItemsBackward(game::ui::screens::GearScreen*, int, game::ItemId);
+    bool GearScreen_LoopTradeItemsForward(game::ui::Anim*, int, game::ItemId, game::ItemId, int);
+    bool GearScreen_LoopTradeItemsBackward(game::ui::Anim*, int, game::ItemId, game::ItemId, int);
     int GearScreen_GetTextIdFromItemId(game::ItemId);
     int GearScreen_GetModelIdFromItemId(game::ItemId);
   }  // namespace gearscreen

--- a/code/include/rnd/item_effect.h
+++ b/code/include/rnd/item_effect.h
@@ -31,6 +31,7 @@ namespace rnd {
   void ItemEffect_FillWalletUpgrade(game::CommonData* comData, s16 arg1, s16 arg2);
   void ItemEffect_GiveRemains(game::CommonData* comData, s16 mask, s16 arg2);
   void ItemEffect_GiveMask(game::CommonData* comData, s16 mask, s16 arg2);
+  void ItemEffect_GiveTradeItem(game::CommonData* comData, s16 mask, s16 arg2);
 }  // namespace rnd
 
 #endif  //_ITEM_EFFECT_H_

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -86,10 +86,9 @@ namespace rnd {
       BitField<41, 1, u64> bottleGoldDustGiven;
       BitField<42, 1, u64> bottleSeahorseGiven;
       BitField<43, 1, u64> bottleChateuGiven;
-      BitField<44, 1, u64> bottleMysteryMilkGiven;
-      BitField<45, 1, u64> bottleRedPotionGiven;
-      BitField<46, 2, u64> progressiveSwordUpgrade;
-      BitField<47, 17, u64> unused;
+      BitField<44, 1, u64> bottleRedPotionGiven;
+      BitField<45, 2, u64> progressiveSwordUpgrade;
+      BitField<46, 18, u64> unused;
     };
     GivenItemRegister givenItemChecks;
     union FairyCollectRegister {

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -3,11 +3,12 @@
 
 #include "common/bitfield.h"
 #include "game/common_data.h"
+#include "game/ui/screens/gearscreen.h"
 #include "rnd/extdata.h"
 #include "z3d/z3DVec.h"
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 15
+#define EXTSAVEDATA_VERSION 16
 #define SAVEFILE_SCENES_DISCOVERED_IDX_COUNT 4
 #define SAVEFILE_SPOILER_ITEM_MAX 512
 
@@ -32,6 +33,7 @@ namespace rnd {
   void SaveFile_LoadExtSaveData(u32 saveNumber);
   u8 SaveFile_GetIsSceneDiscovered(u8 sceneNum);
   extern "C" void SaveFile_SaveExtSaveData();
+  extern "C" void SaveFile_GetStoredTradeItem(game::ui::screens::GearScreen*);
 
   typedef struct {
     u32 version;  // Needs to always be the first field of the structure
@@ -115,6 +117,7 @@ namespace rnd {
     u32 scenesDiscovered[SAVEFILE_SCENES_DISCOVERED_IDX_COUNT];
     u8 itemCollected[SAVEFILE_SPOILER_ITEM_MAX];
     u8 chestRewarded[116][32];  // Reward table that's stored by scene and chest param/flag.
+    game::ItemId collectedTradeItems[9];
   } ExtSaveData;
 
   extern "C" ExtSaveData gExtSaveData;

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -37,7 +37,7 @@ namespace rnd {
   extern "C" void SaveFile_RemoveTradeItemFromSlot(u16, u8);
   extern "C" u8 SaveFile_GetItemCurrentlyInSlot(u8);
 
-      typedef struct {
+  typedef struct {
     u32 version;  // Needs to always be the first field of the structure
     u32 playtimeSeconds;
     u32 isNewFile;

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -33,10 +33,11 @@ namespace rnd {
   void SaveFile_LoadExtSaveData(u32 saveNumber);
   u8 SaveFile_GetIsSceneDiscovered(u8 sceneNum);
   extern "C" void SaveFile_SaveExtSaveData();
-  extern "C" void SaveFile_RemoveStoredDeed(u16, u8);
+  extern "C" void SaveFile_RemoveStoredTradeItem(u16, u8);
   extern "C" void SaveFile_RemoveTradeItemFromSlot(u16, u8);
+  extern "C" u8 SaveFile_GetItemCurrentlyInSlot(u8);
 
-  typedef struct {
+      typedef struct {
     u32 version;  // Needs to always be the first field of the structure
     u32 playtimeSeconds;
     u32 isNewFile;
@@ -95,12 +96,12 @@ namespace rnd {
     union FairyCollectRegister {
       u8 raw;
 
-      BitField<0, 1, u8> nct;
-      BitField<1, 1, u8> woodfall;
-      BitField<2, 1, u8> snowhead;
-      BitField<3, 1, u8> great_bay;
-      BitField<4, 1, u8> ikana;
-      BitField<5, 3, u8> unused;
+      BitField<0, 2, u8> nct;
+      BitField<2, 1, u8> woodfall;
+      BitField<3, 1, u8> snowhead;
+      BitField<4, 1, u8> great_bay;
+      BitField<5, 1, u8> ikana;
+      BitField<6, 2, u8> unused;
     };
     FairyCollectRegister fairyRewards;
     union TingleCollectRegister {

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -33,7 +33,7 @@ namespace rnd {
   void SaveFile_LoadExtSaveData(u32 saveNumber);
   u8 SaveFile_GetIsSceneDiscovered(u8 sceneNum);
   extern "C" void SaveFile_SaveExtSaveData();
-  extern "C" void SaveFile_GetStoredTradeItem(game::ui::screens::GearScreen*);
+  extern "C" void SaveFile_RemoveStoredDeed(u16, u8);
 
   typedef struct {
     u32 version;  // Needs to always be the first field of the structure

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -34,6 +34,7 @@ namespace rnd {
   u8 SaveFile_GetIsSceneDiscovered(u8 sceneNum);
   extern "C" void SaveFile_SaveExtSaveData();
   extern "C" void SaveFile_RemoveStoredDeed(u16, u8);
+  extern "C" void SaveFile_RemoveTradeItemFromSlot(u16, u8);
 
   typedef struct {
     u32 version;  // Needs to always be the first field of the structure

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -87,8 +87,9 @@ namespace rnd {
       BitField<42, 1, u64> bottleSeahorseGiven;
       BitField<43, 1, u64> bottleChateuGiven;
       BitField<44, 1, u64> bottleMysteryMilkGiven;
-      BitField<45, 2, u64> progressiveSwordUpgrade;
-      BitField<46, 18, u64> unused;
+      BitField<45, 1, u64> bottleRedPotionGiven;
+      BitField<46, 2, u64> progressiveSwordUpgrade;
+      BitField<47, 17, u64> unused;
     };
     GivenItemRegister givenItemChecks;
     union FairyCollectRegister {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -363,6 +363,10 @@ SECTIONS{
     *(.patch_CheckMoTRequirement)
   }
 
+  .patch_TradeItemDeleteMoonsTear 0x3B5280 : {
+    *(.patch_TradeItemDeleteMoonsTear)
+  }
+
   .patch_OverrideWalletSpiderHouseTwo 0x3BF078 : {
     *(.patch_OverrideWalletSpiderHouseTwo)
   }
@@ -401,6 +405,22 @@ SECTIONS{
 
   .patch_CouplesMaskGiveItem 0x46E228 : {
     *(.patch_CouplesMaskGiveItem)
+  }
+
+  .patch_TradeItemDeleteLandTitleDeed 0x477710 : {
+    *(.patch_TradeItemDeleteLandTitleDeed)
+  }
+
+  .patch_TradeItemDeleteSwampTitleDeed 0x47771C : {
+    *(.patch_TradeItemDeleteSwampTitleDeed)
+  }
+
+  .patch_TradeItemDeleteMountainTitleDeed 0x477728 : {
+    *(.patch_TradeItemDeleteMountainTitleDeed)
+  }
+
+  .patch_TradeItemDeleteOceanTitleDeed 0x477748 : {
+    *(.patch_TradeItemDeleteOceanTitleDeed)
   }
 
   .patch_LoadExtData 0x48C760 : {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -55,6 +55,10 @@ SECTIONS{
     *(.patch_KeepBowOnEpona)
   }
 
+  .patch_RemoveTradeItemFromSlot 0x1AFE8C : {
+    *(.patch_RemoveTradeItemFromSlot)
+  }
+
   .patch_OverrideCutsceneNextEntrance 0x1B1834 : {
     *(.patch_OverrideCutsceneNextEntrance)
   }
@@ -363,9 +367,9 @@ SECTIONS{
     *(.patch_CheckMoTRequirement)
   }
 
-  .patch_TradeItemDeleteMoonsTear 0x3B5280 : {
+  /* .patch_TradeItemDeleteMoonsTear 0x3B5280 : {
     *(.patch_TradeItemDeleteMoonsTear)
-  }
+  } */
 
   .patch_OverrideWalletSpiderHouseTwo 0x3BF078 : {
     *(.patch_OverrideWalletSpiderHouseTwo)
@@ -411,16 +415,12 @@ SECTIONS{
     *(.patch_TradeItemDeleteLandTitleDeed)
   }
 
-  .patch_TradeItemDeleteSwampTitleDeed 0x47771C : {
+   .patch_TradeItemDeleteSwampTitleDeed 0x47771C : {
     *(.patch_TradeItemDeleteSwampTitleDeed)
   }
 
   .patch_TradeItemDeleteMountainTitleDeed 0x477728 : {
     *(.patch_TradeItemDeleteMountainTitleDeed)
-  }
-
-  .patch_TradeItemDeleteOceanTitleDeed 0x477748 : {
-    *(.patch_TradeItemDeleteOceanTitleDeed)
   }
 
   .patch_LoadExtData 0x48C760 : {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -347,6 +347,10 @@ SECTIONS{
     *(.patch_IceArrowsAnywhere)
   }
 
+  .patch_changeChestTypeToMatchContents 0x31cad4 : {
+    *(.patch_changeChestTypeToMatchContents)
+  }
+
   .patch_RemoveZoraMaskCheckMikau 0x32BBB8 : {
     *(.patch_RemoveZoraMaskCheckMikau)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -415,6 +415,10 @@ SECTIONS{
     *(.patch_DisableExistingTrigger)
   }
 
+  .patch_SwapStoredTradeItems 0x5a6b44 : {
+    *(.patch_SwapStoredTradeItems)
+  }
+
   .patch_ShorterAnimationOpen 0x5B1758 : {
     *(.patch_ShorterAnimationOpenOne)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -367,9 +367,9 @@ SECTIONS{
     *(.patch_CheckMoTRequirement)
   }
 
-  /* .patch_TradeItemDeleteMoonsTear 0x3B5280 : {
+  .patch_TradeItemDeleteMoonsTear 0x3B5214 : {
     *(.patch_TradeItemDeleteMoonsTear)
-  } */
+  }
 
   .patch_OverrideWalletSpiderHouseTwo 0x3BF078 : {
     *(.patch_OverrideWalletSpiderHouseTwo)
@@ -425,6 +425,10 @@ SECTIONS{
 
   .patch_LoadExtData 0x48C760 : {
     *(.patch_LoadExtData)
+  }
+
+  .patch_RemoveKafeiItemFromExtSlot 0x4AD1B8 : {
+    *(.patch_RemoveKafeiItemFromExtSlot)
   }
 
   .patch_IncomingGetItemID 0x4B1394 : {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -67,6 +67,10 @@ SECTIONS{
     *(.patch_DoNotResetTempleFlags)
   } 
 
+  .patch_DoNotRemoveTradeItems 0x1c9aa8 : {
+    *(.patch_DoNotRemoveTradeItems)
+  }
+
   .patch_DoNotRemoveKeys 0x1C9B94 : {
     *(.patch_DoNotRemoveKeys)
   }

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -307,6 +307,14 @@ hook_readGamePad:
     tst r0,r1
     b 0x59ba14
 
+.global hook_SwapStoredTradeItems
+hook_SwapStoredTradeItems:
+    push {r0-r12, lr}
+    bl GearScreen_GetStoredTradeItem
+    pop {r0-r12, lr}
+    cpy r4, r0
+    bx lr
+
 .global hook_HandleOcarina
 hook_HandleOcarina:
     push {r0-r12, lr}

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -355,7 +355,7 @@ hook_changeChestTypeToMatchContents:
     ldrh r2,[r4,#0x1C]
     lsl r2, r2, #0x14
     lsr r2,r2, #0x19
-    bl Chest_OverrideTexture
+    bl Chest_OverrideSize
     cmp r0,#0xFF
     beq doNotOverrideChestType
     strb r0,[r4,#0x3e9]

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -307,14 +307,6 @@ hook_readGamePad:
     tst r0,r1
     b 0x59ba14
 
-.global hook_SwapStoredTradeItems
-hook_SwapStoredTradeItems:
-    push {r0-r12, lr}
-    bl GearScreen_GetStoredTradeItem
-    pop {r0-r12, lr}
-    cpy r4, r0
-    bx lr
-
 .global hook_HandleOcarina
 hook_HandleOcarina:
     push {r0-r12, lr}

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -355,6 +355,26 @@ hook_OwlExtDataSave:
     cpy r6,r0
     b 0x317008
 
+.global hook_changeChestTypeToMatchContents
+hook_changeChestTypeToMatchContents:
+    push {r0-r2, lr}
+    cpy r0, r4
+    cpy r1, r5
+    ldrh r2,[r4,#0x1C]
+    lsl r2, r2, #0x14
+    lsr r2,r2, #0x19
+    bl Chest_OverrideTexture
+    cmp r0,#0xFF
+    beq doNotOverrideChestType
+    strb r0,[r4,#0x3e9]
+    pop {r0-r2, lr}
+    bx lr
+doNotOverrideChestType:
+    pop {r0-r2, lr}
+    strb r2,[r4,#0x3e9]
+    bx lr
+
+
 .global hook_MikauRewardCheck
 hook_MikauRewardCheck:
     push {r0-r12, lr}

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -324,6 +324,11 @@ patch_ReadGamePad:
 patch_DisableExistingTrigger:
     b 0x059bb60 @branches past all the checks for button presses and whatnot. We override all of this.
 
+.section .patch_SwapStoredTradeItems
+.global patch_SwapStoredTradeItems
+patch_SwapStoredTradeItems:
+    bl hook_SwapStoredTradeItems
+
 .section .patch_ItemCloseOnSelect
 .global patch_ItemCloseOnSelect
 patch_ItemCloseOnSelect:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -389,6 +389,12 @@ patch_SaveExtDataOnOwl:
 patch_IceArrowsAnywhere:
     nop
 
+.section .patch_changeChestTypeToMatchContents
+.global patch_changeChestTypeToMatchContents
+patch_changeChestTypeToMatchContents:
+    bl hook_changeChestTypeToMatchContents
+    @mov r2, #0x02
+
 .section .patch_RemoveZoraMaskCheckMikau
 .global patch_RemoveZoraMaskCheckMikau
 patch_RemoveZoraMaskCheckMikau:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -104,10 +104,6 @@ patch_RemoveMysteryMilkTimer:
 patch_DoNotResetTempleFlags:
     bl hook_DoNotResetTempleFlags
 
-.section .patch_DoNotRemoveTradeItems
-.global patch_DoNotRemoveTradeItems
-patch_DoNotRemoveTradeItems:
-    b 0x1C9AD0
 
 @ Skips past a loop that resets all
 @ values in the each dungeon for 
@@ -328,11 +324,6 @@ patch_ReadGamePad:
 .global patch_DisableExistingTrigger
 patch_DisableExistingTrigger:
     b 0x059bb60 @branches past all the checks for button presses and whatnot. We override all of this.
-
-.section .patch_SwapStoredTradeItems
-.global patch_SwapStoredTradeItems
-patch_SwapStoredTradeItems:
-    bl hook_SwapStoredTradeItems
 
 .section .patch_ItemCloseOnSelect
 .global patch_ItemCloseOnSelect

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -104,6 +104,11 @@ patch_RemoveMysteryMilkTimer:
 patch_DoNotResetTempleFlags:
     bl hook_DoNotResetTempleFlags
 
+.section .patch_DoNotRemoveTradeItems
+.global patch_DoNotRemoveTradeItems
+patch_DoNotRemoveTradeItems:
+    b 0x1C9AD0
+
 @ Skips past a loop that resets all
 @ values in the each dungeon for 
 @ keys/fairies/boss key/etc

--- a/code/source/asm/trade_item_hooks.s
+++ b/code/source/asm/trade_item_hooks.s
@@ -7,18 +7,55 @@ hook_RemoveTradeItemFromInventory:
   cpy r0,r2
   mov r1,#0x5
   sub r0,r0,#0x1
-  bl SaveFile_RemoveStoredDeed
+  bl SaveFile_RemoveStoredTradeItem
   pop {r0-r12,lr}
   beq 0x477748
   bx lr
 
+.global hook_RemoveMoonTearFromInventory
+hook_RemoveMoonTearFromInventory:
+  push {r0-r12,lr}
+  mov r2, #0x97
+  cpy r0,r2
+  mov r1,#0x5
+  sub r0,r0,#0x1
+  bl SaveFile_RemoveStoredTradeItem
+  pop {r0-r12,lr}
+  cpy r5,r1
+  bx lr
+
 .global hook_RemoveTradeItemFromExtSlot
 hook_RemoveTradeItemFromExtSlot:
-  push {r0-r12}
+  push {r0-r12, lr}
   bl SaveFile_RemoveTradeItemFromSlot 
-  pop {r0-r12}
+  pop {r0-r12, lr}
   cpy r2,r1
   bx lr
+
+.global hook_RemoveKafeiItemFromExtSlot
+hook_RemoveKafeiItemFromExtSlot:
+  push {r0-r12, lr}
+  bl SaveFile_GetItemCurrentlyInSlot
+  cmp r0,#0x2F
+  beq changeLetter
+  cmp r0,#0x30
+  beq changePendant
+  pop {r0-r12, lr}
+  cpy r5,r0
+  bx lr
+changeLetter:
+  mov r0,#0xAA
+  mov r1,#0x11
+  bl SaveFile_RemoveStoredTradeItem
+  pop {r0-r12,lr}
+  b 0x4AD1C4
+changePendant:
+  mov r0,#0xAB
+  mov r1,#0x11
+  bl SaveFile_RemoveStoredTradeItem
+  pop {r0-r12,lr}
+  b 0x4AD1C4
+  
 
 .global hook_SwapStoredTradeItems
 hook_SwapStoredTradeItems:

--- a/code/source/asm/trade_item_hooks.s
+++ b/code/source/asm/trade_item_hooks.s
@@ -1,0 +1,20 @@
+.arm
+.text
+
+.global hook_RemoveTradeItemFromInventory
+hook_RemoveTradeItemFromInventory:
+  push {r0-r12,lr}
+  cpy r0,r2
+  mov r1,#0x5
+  sub r0,r0,#0x1
+  bl SaveFile_RemoveStoredDeed
+  pop {r0-r12,lr}
+  bx lr
+
+.global hook_SwapStoredTradeItems
+hook_SwapStoredTradeItems:
+  push {r0-r12, lr}
+  bl GearScreen_GetStoredTradeItem
+  pop {r0-r12, lr}
+  cpy r4, r0
+  bx lr

--- a/code/source/asm/trade_item_hooks.s
+++ b/code/source/asm/trade_item_hooks.s
@@ -9,6 +9,15 @@ hook_RemoveTradeItemFromInventory:
   sub r0,r0,#0x1
   bl SaveFile_RemoveStoredDeed
   pop {r0-r12,lr}
+  beq 0x477748
+  bx lr
+
+.global hook_RemoveTradeItemFromExtSlot
+hook_RemoveTradeItemFromExtSlot:
+  push {r0-r12}
+  bl SaveFile_RemoveTradeItemFromSlot 
+  pop {r0-r12}
+  cpy r2,r1
   bx lr
 
 .global hook_SwapStoredTradeItems

--- a/code/source/asm/trade_item_patches.s
+++ b/code/source/asm/trade_item_patches.s
@@ -13,9 +13,7 @@ patch_DoNotRemoveTradeItems:
 .section .patch_TradeItemDeleteMoonsTear
 .global patch_TradeItemDeleteMoonsTear
 patch_TradeItemDeleteMoonsTear:
-  mov r2,#0x96
-  bl hook_RemoveTradeItemFromInventory
-  mov r2,#0x97
+  bl hook_RemoveMoonTearFromInventory
 
 .section .patch_TradeItemDeleteLandTitleDeed
 .global patch_TradeItemDeleteLandTitleDeed
@@ -32,6 +30,10 @@ patch_TradeItemDeleteSwampTitleDeed:
 patch_TradeItemDeleteMountainTitleDeed:
   bleq hook_RemoveTradeItemFromInventory
 
+.section .patch_RemoveKafeiItemFromExtSlot
+.global patch_RemoveKafeiItemFromExtSlot
+patch_RemoveKafeiItemFromExtSlot:
+  bl hook_RemoveKafeiItemFromExtSlot
 
 .section .patch_SwapStoredTradeItems
 .global patch_SwapStoredTradeItems

--- a/code/source/asm/trade_item_patches.s
+++ b/code/source/asm/trade_item_patches.s
@@ -1,0 +1,39 @@
+.arm
+
+
+.section .patch_DoNotRemoveTradeItems
+.global patch_DoNotRemoveTradeItems
+patch_DoNotRemoveTradeItems:
+  b 0x1C9AD0
+
+.section .patch_TradeItemDeleteMoonsTear
+.global patch_TradeItemDeleteMoonsTear
+patch_TradeItemDeleteMoonsTear:
+  mov r2,#0x96
+  bl hook_RemoveTradeItemFromInventory
+  mov r2,#0x97
+
+.section .patch_TradeItemDeleteLandTitleDeed
+.global patch_TradeItemDeleteLandTitleDeed
+patch_TradeItemDeleteLandTitleDeed:
+  bl hook_RemoveTradeItemFromInventory
+  
+.section .patch_TradeItemDeleteSwampTitleDeed
+.global patch_TradeItemDeleteSwampTitleDeed
+patch_TradeItemDeleteSwampTitleDeed:
+  bleq hook_RemoveTradeItemFromInventory
+  
+.section .patch_TradeItemDeleteMountainTitleDeed
+.global patch_TradeItemDeleteMountainTitleDeed
+patch_TradeItemDeleteMountainTitleDeed:
+  bleq hook_RemoveTradeItemFromInventory
+  
+.section .patch_TradeItemDeleteOceanTitleDeed
+.global patch_TradeItemDeleteOceanTitleDeed
+patch_TradeItemDeleteOceanTitleDeed:
+  bleq hook_RemoveTradeItemFromInventory
+
+.section .patch_SwapStoredTradeItems
+.global patch_SwapStoredTradeItems
+patch_SwapStoredTradeItems:
+  bl hook_SwapStoredTradeItems

--- a/code/source/asm/trade_item_patches.s
+++ b/code/source/asm/trade_item_patches.s
@@ -1,5 +1,9 @@
 .arm
 
+.section .patch_RemoveTradeItemFromSlot
+.global patch_RemoveTradeItemFromSlot
+patch_RemoveTradeItemFromSlot:
+  bleq hook_RemoveTradeItemFromExtSlot
 
 .section .patch_DoNotRemoveTradeItems
 .global patch_DoNotRemoveTradeItems
@@ -16,7 +20,7 @@ patch_TradeItemDeleteMoonsTear:
 .section .patch_TradeItemDeleteLandTitleDeed
 .global patch_TradeItemDeleteLandTitleDeed
 patch_TradeItemDeleteLandTitleDeed:
-  bl hook_RemoveTradeItemFromInventory
+  bleq hook_RemoveTradeItemFromInventory
   
 .section .patch_TradeItemDeleteSwampTitleDeed
 .global patch_TradeItemDeleteSwampTitleDeed
@@ -27,11 +31,7 @@ patch_TradeItemDeleteSwampTitleDeed:
 .global patch_TradeItemDeleteMountainTitleDeed
 patch_TradeItemDeleteMountainTitleDeed:
   bleq hook_RemoveTradeItemFromInventory
-  
-.section .patch_TradeItemDeleteOceanTitleDeed
-.global patch_TradeItemDeleteOceanTitleDeed
-patch_TradeItemDeleteOceanTitleDeed:
-  bleq hook_RemoveTradeItemFromInventory
+
 
 .section .patch_SwapStoredTradeItems
 .global patch_SwapStoredTradeItems

--- a/code/source/game/ui/screens/gearscreen.cpp
+++ b/code/source/game/ui/screens/gearscreen.cpp
@@ -1,0 +1,8 @@
+#include "game/ui/screens/gearscreen.h"
+
+namespace game::ui::screens {
+  GearScreen* GetGearScreen() {
+    return rnd::util::GetPointer<GearScreen>(0x6F4130);
+  }
+
+}  // namespace game::ui::screens

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -76,12 +76,6 @@ namespace rnd {
 
     context.gctx = static_cast<game::GlobalContext*>(state);
     Input_Update();
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    const u32 newButtons = context.gctx->pad_state.input.new_buttons.flags;
-    game::ui::screens::GearScreen* gearScreen = game::ui::screens::GetGearScreen();
-    if (newButtons == (u32)game::pad::Button::ZR)
-      rnd::util::Print("%s: Field 195 is %u\n", __func__, gearScreen->cursorIndex);
-#endif
     if (context.gctx->GetPlayerActor()) {
       ItemOverride_Update();
       link::HandleFastOcarina(context.gctx);

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -6,6 +6,7 @@
 #include "game/sound.h"
 #include "game/states/state.h"
 #include "game/ui.h"
+#include "game/ui/screens/gearscreen.h"
 #include "rnd/extdata.h"
 #include "rnd/icetrap.h"
 #include "rnd/input.h"
@@ -75,6 +76,12 @@ namespace rnd {
 
     context.gctx = static_cast<game::GlobalContext*>(state);
     Input_Update();
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    const u32 newButtons = context.gctx->pad_state.input.new_buttons.flags;
+    game::ui::screens::GearScreen* gearScreen = game::ui::screens::GetGearScreen();
+    if (newButtons == (u32)game::pad::Button::ZR)
+      rnd::util::Print("%s: Field 195 is %u\n", __func__, gearScreen->cursorIndex);
+#endif
     if (context.gctx->GetPlayerActor()) {
       ItemOverride_Update();
       link::HandleFastOcarina(context.gctx);
@@ -99,11 +106,7 @@ namespace rnd {
 
     const u32 pressedButtons = gctx->pad_state.input.buttons.flags;
     const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    auto* saveData = GetContext().gctx->GetPlayerActor();
-    if (newButtons == (u32)game::pad::Button::ZR)
-      rnd::util::Print("%s: Flag is %#08x\n", __func__, saveData->flags1);
-#endif
+
     if (gSettingsContext.customMaskButton != 0 && pressedButtons == gSettingsContext.customMaskButton) {
       game::ui::OpenScreen(game::ui::ScreenType::Masks);
     } else if (gSettingsContext.customItemButton != 0 && pressedButtons == gSettingsContext.customItemButton) {

--- a/code/source/rnd/chest.cpp
+++ b/code/source/rnd/chest.cpp
@@ -11,7 +11,7 @@ namespace rnd {
     }
     game::SceneId scene = gctx->scene;
     ItemOverride override = ItemOverride_Lookup((game::act::Actor*)&actor->dyna, (u16)scene, gid);
-    if (override.key.all != 0 &&) {
+    if (override.key.all != 0) {
       ItemRow* itemToBeGiven = ItemTable_GetItemRow(override.value.getItemId);
       if (actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_SMALL ||
           actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_BIG ||

--- a/code/source/rnd/chest.cpp
+++ b/code/source/rnd/chest.cpp
@@ -1,0 +1,39 @@
+#include "rnd/chest.h"
+#include "rnd/item_table.h"
+
+namespace rnd {
+  extern "C" {
+  game::actors::EnBoxType Chest_OverrideTexture(game::actors::En_Box* actor, game::GlobalContext* gctx, s16 gid) {
+    // First check to see if setting is enabled.
+    // TODO: Create setting
+    if (gSettingsContext.chestSize == 0) {
+      return (game::actors::EnBoxType)0xFF;
+    }
+    game::SceneId scene = gctx->scene;
+    ItemOverride override = ItemOverride_Lookup((game::act::Actor*)&actor->dyna, (u16)scene, gid);
+    if (override.key.all != 0 &&) {
+      ItemRow* itemToBeGiven = ItemTable_GetItemRow(override.value.getItemId);
+      if (actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_SMALL ||
+          actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_BIG ||
+          actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_BIG_ORNATE) {
+        if (itemToBeGiven->baseItemId == 0x02)
+          return game::actors::EnBoxType::ENBOX_TYPE_SMALL;
+        else if (itemToBeGiven->baseItemId == 0x2B)
+          return game::actors::EnBoxType::ENBOX_TYPE_BIG;
+        else if (itemToBeGiven->baseItemId == 0x78)
+          return game::actors::EnBoxType::ENBOX_TYPE_BIG_ORNATE;
+      } else if (actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_BIG_INVISIBLE ||
+                 actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_SMALL_INVISIBLE) {
+        if (itemToBeGiven->baseItemId == 0x02)
+          return game::actors::EnBoxType::ENBOX_TYPE_SMALL_INVISIBLE;
+        else if (itemToBeGiven->baseItemId == 0x2B || itemToBeGiven->baseItemId == 0x78)
+          return game::actors::EnBoxType::ENBOX_TYPE_BIG_INVISIBLE;
+      }
+    } else {
+      return (game::actors::EnBoxType)0xFF;
+    }
+    return (game::actors::EnBoxType)0xFF;
+  }
+  }
+
+}  // namespace rnd

--- a/code/source/rnd/chest.cpp
+++ b/code/source/rnd/chest.cpp
@@ -3,7 +3,7 @@
 
 namespace rnd {
   extern "C" {
-  game::actors::EnBoxType Chest_OverrideTexture(game::actors::En_Box* actor, game::GlobalContext* gctx, s16 gid) {
+  game::actors::EnBoxType Chest_OverrideSize(game::actors::En_Box* actor, game::GlobalContext* gctx, s16 gid) {
     // First check to see if setting is enabled.
     // TODO: Create setting
     if (gSettingsContext.chestSize == 0) {
@@ -18,10 +18,8 @@ namespace rnd {
           actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_BIG_ORNATE) {
         if (itemToBeGiven->baseItemId == 0x02)
           return game::actors::EnBoxType::ENBOX_TYPE_SMALL;
-        else if (itemToBeGiven->baseItemId == 0x2B)
+        else if (itemToBeGiven->baseItemId == 0x2B || itemToBeGiven->baseItemId == 0x78)
           return game::actors::EnBoxType::ENBOX_TYPE_BIG;
-        else if (itemToBeGiven->baseItemId == 0x78)
-          return game::actors::EnBoxType::ENBOX_TYPE_BIG_ORNATE;
       } else if (actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_BIG_INVISIBLE ||
                  actor->chest_type == game::actors::EnBoxType::ENBOX_TYPE_SMALL_INVISIBLE) {
         if (itemToBeGiven->baseItemId == 0x02)

--- a/code/source/rnd/custom_screen.cpp
+++ b/code/source/rnd/custom_screen.cpp
@@ -5,14 +5,13 @@ namespace rnd {
   namespace gearscreen {
 
     extern "C" void GearScreen_GetStoredTradeItem(game::ui::screens::GearScreen* gearScreen) {
+      auto* gctx = rnd::GetContext().gctx;
+      auto& items = game::GetCommonData().save.inventory.items;
+      game::ItemId firstFoundItem = game::ItemId::None;
+      const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
       if (gearScreen->cursorIndex == 0) {
-        auto* gctx = rnd::GetContext().gctx;
-        game::ItemId firstFoundItem = game::ItemId::None;
-        const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
-        
-        // Sixth Slot [5] of Inventory array is the Title deed slot. 17 [16] is letter to kafei?
+        // Sixth Slot [5] of Inventory array is the Title deed slot.
         if (newButtons == (u32)game::pad::Button::R) {
-
           // Check what is in current slot.
           // After receiving value, check array from 0-4 to see what items we have obtained.
           // We always know the order of the array, MoonsTear -> Land Title -> Swamp -> Mountain -> Ocean
@@ -20,95 +19,111 @@ namespace rnd {
             if (firstFoundItem == game::ItemId::None) {
               firstFoundItem = gExtSaveData.collectedTradeItems[i];
             }
-            if (GearScreen_LoopTradeItemsForward(gearScreen, i, firstFoundItem)) break;
+            if (GearScreen_LoopTradeItemsForward(gearScreen->icon_event00_l->return_empty_idle_anim, i, firstFoundItem,
+                                                 items[5], 4))
+              break;
           }
         } else if (newButtons == (u32)game::pad::Button::L) {
           for (int i = 4; i >= 0; i--) {
             if (firstFoundItem == game::ItemId::None) {
               firstFoundItem = gExtSaveData.collectedTradeItems[i];
             }
-            if (GearScreen_LoopTradeItemsBackward(gearScreen, i, firstFoundItem)) break;
+            if (GearScreen_LoopTradeItemsBackward(gearScreen->icon_event00_l->return_empty_idle_anim, i, firstFoundItem,
+                                                  items[5], 0))
+              break;
           }
         }
-      } else if (gearScreen->cursorIndex == 2) {
-        #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-          rnd::util::Print("%s: Index 2!\n", __func__);	
-        #endif
+      } else if (gearScreen->cursorIndex == 1) {
+        // 18 [17] is letter to kafei/mama.
+        if (newButtons == (u32)game::pad::Button::R) {
+          // Check what is in current slot.
+          // After receiving value, check array from 0-4 to see what items we have obtained.
+          // We always know the order of the array, MoonsTear -> Land Title -> Swamp -> Mountain -> Ocean
+          for (int i = 6; i < 8; i++) {
+            if (firstFoundItem == game::ItemId::None) {
+              firstFoundItem = gExtSaveData.collectedTradeItems[i];
+            }
+            if (GearScreen_LoopTradeItemsForward(gearScreen->icon_event01_l->return_empty_idle_anim, i, firstFoundItem,
+                                                 items[17], 7))
+              break;
+          }
+        } else if (newButtons == (u32)game::pad::Button::L) {
+          for (int i = 7; i > 5; i--) {
+            if (firstFoundItem == game::ItemId::None) {
+              firstFoundItem = gExtSaveData.collectedTradeItems[i];
+            }
+            if (GearScreen_LoopTradeItemsBackward(gearScreen->icon_event01_l->return_empty_idle_anim, i, firstFoundItem,
+                                                  items[17], 4))
+              break;
+          }
+        }
       }
       return;
     }
 
-    bool GearScreen_LoopTradeItemsForward(game::ui::screens::GearScreen* gearScreen,int i, game::ItemId firstFoundItem) {
-      auto& items = game::GetCommonData().save.inventory.items;
+    bool GearScreen_LoopTradeItemsForward(game::ui::Anim* gearScreenIdleAnim, int i, game::ItemId firstFoundItem,
+                                          game::ItemId itemInSlot, int lastItemSlot) {
       int textId;
       int modelId;
-      
+
       // Base case, if we have a none item, give the first available item.
-      if (items[5] == game::ItemId::None && gExtSaveData.collectedTradeItems[i] != game::ItemId::None) {
+      if (itemInSlot == game::ItemId::None && gExtSaveData.collectedTradeItems[i] != game::ItemId::None) {
         textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
         modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
-        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
-                                textId, modelId);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i], gearScreenIdleAnim, textId, modelId);
         return true;
       }
       // Second case - we're not the last element and we contain an item, then swap that item.
-      if (i != 4 && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
-          (int)items[5] < (int)gExtSaveData.collectedTradeItems[i]) {
+      if (i != lastItemSlot && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
+          (int)itemInSlot < (int)gExtSaveData.collectedTradeItems[i]) {
         textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
         modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
-        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
-                                textId, modelId);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i], gearScreenIdleAnim, textId, modelId);
         return true;
-      } else if (i == 4 && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
-        gExtSaveData.collectedTradeItems[i] != items[5]) {
+      } else if (i == lastItemSlot && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
+                 gExtSaveData.collectedTradeItems[i] != itemInSlot) {
         textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
         modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
-        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
-                                textId, modelId);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i], gearScreenIdleAnim, textId, modelId);
         return true;
-      } else if (i == 4 && firstFoundItem != game::ItemId::None) {
+      } else if (i == lastItemSlot && firstFoundItem != game::ItemId::None) {
         textId = GearScreen_GetTextIdFromItemId(firstFoundItem);
         modelId = GearScreen_GetModelIdFromItemId(firstFoundItem);
-        GearScreen_DrawAndShowItem(firstFoundItem , gearScreen->icon_event00_l->return_empty_idle_anim,
-                                textId, modelId);
+        GearScreen_DrawAndShowItem(firstFoundItem, gearScreenIdleAnim, textId, modelId);
         return true;
       }
       return false;
     }
 
-    bool GearScreen_LoopTradeItemsBackward(game::ui::screens::GearScreen* gearScreen,int i, game::ItemId firstFoundItem) {
-      auto& items = game::GetCommonData().save.inventory.items;
+    bool GearScreen_LoopTradeItemsBackward(game::ui::Anim* gearScreenIdleAnim, int i, game::ItemId firstFoundItem,
+                                           game::ItemId itemInSlot, int lastItemSlot) {
       int textId;
       int modelId;
-      
+
       // Base case, if we have a none item, give the first available item.
-      if (items[5] == game::ItemId::None && gExtSaveData.collectedTradeItems[i] != game::ItemId::None) {
+      if (itemInSlot == game::ItemId::None && gExtSaveData.collectedTradeItems[i] != game::ItemId::None) {
         textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
         modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
-        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
-                                textId, modelId);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i], gearScreenIdleAnim, textId, modelId);
         return true;
       }
       // Second case - we're not the last element and we contain an item, then swap that item.
-      if (i != 0 && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
-          (int)items[5] > (int)gExtSaveData.collectedTradeItems[i]) {
+      if (i != lastItemSlot && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
+          (int)itemInSlot > (int)gExtSaveData.collectedTradeItems[i]) {
         textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
         modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
-        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
-                                textId, modelId);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i], gearScreenIdleAnim, textId, modelId);
         return true;
-      } else if (i == 0 && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
-        gExtSaveData.collectedTradeItems[i] != items[5]) {
+      } else if (i == lastItemSlot && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
+                 gExtSaveData.collectedTradeItems[i] != itemInSlot) {
         textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
         modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
-        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
-                                textId, modelId);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i], gearScreenIdleAnim, textId, modelId);
         return true;
-      } else if (i == 0 && firstFoundItem != game::ItemId::None) {
+      } else if (i == lastItemSlot && firstFoundItem != game::ItemId::None) {
         textId = GearScreen_GetTextIdFromItemId(firstFoundItem);
         modelId = GearScreen_GetModelIdFromItemId(firstFoundItem);
-        GearScreen_DrawAndShowItem(firstFoundItem , gearScreen->icon_event00_l->return_empty_idle_anim,
-                                textId, modelId);
+        GearScreen_DrawAndShowItem(firstFoundItem, gearScreenIdleAnim, textId, modelId);
         return true;
       }
       return false;
@@ -116,37 +131,50 @@ namespace rnd {
 
     int GearScreen_GetTextIdFromItemId(game::ItemId itemId) {
       // Since we're limited on what items we got, just hard code these.
-      if (itemId == game::ItemId::MoonTear) return 0x1728;
-      else if (itemId == game::ItemId::LandTitleDeed) return 0x1729; 
-      else if (itemId == game::ItemId::SwampTitleDeed) return 0x172A; 
-      else if (itemId == game::ItemId::MountainTitleDeed) return 0x172B; 
-      else if (itemId == game::ItemId::OceanTitleDeed) return 0x172C; 
-      else if (itemId == game::ItemId::LetterToKafei) return 0x172F; 
-      else if (itemId == game::ItemId::PendantOfMemories) return 0x1730;
+      if (itemId == game::ItemId::MoonTear)
+        return 0x1728;
+      else if (itemId == game::ItemId::LandTitleDeed)
+        return 0x1729;
+      else if (itemId == game::ItemId::SwampTitleDeed)
+        return 0x172A;
+      else if (itemId == game::ItemId::MountainTitleDeed)
+        return 0x172B;
+      else if (itemId == game::ItemId::OceanTitleDeed)
+        return 0x172C;
+      else if (itemId == game::ItemId::LetterToKafei)
+        return 0x172F;
+      else if (itemId == game::ItemId::PendantOfMemories)
+        return 0x1730;
       return 0x00;
     }
 
     int GearScreen_GetModelIdFromItemId(game::ItemId itemId) {
       // Since we're limited on what items we got, just hard code these.
-      if (itemId == game::ItemId::MoonTear) return 0x59;
-      else if (itemId == game::ItemId::LandTitleDeed) return 0x5A; 
-      else if (itemId == game::ItemId::SwampTitleDeed) return 0x40; 
-      else if (itemId == game::ItemId::MountainTitleDeed) return 0x41; 
-      else if (itemId == game::ItemId::OceanTitleDeed) return 0x43; 
-      else if (itemId == game::ItemId::LetterToKafei) return 0x40; 
-      else if (itemId == game::ItemId::PendantOfMemories) return 0x00;
+      if (itemId == game::ItemId::MoonTear)
+        return 0x59;
+      else if (itemId == game::ItemId::LandTitleDeed)
+        return 0x5A;
+      else if (itemId == game::ItemId::SwampTitleDeed)
+        return 0x40;
+      else if (itemId == game::ItemId::MountainTitleDeed)
+        return 0x41;
+      else if (itemId == game::ItemId::OceanTitleDeed)
+        return 0x43;
+      else if (itemId == game::ItemId::LetterToKafei)
+        return 0x6D;
+      else if (itemId == game::ItemId::PendantOfMemories)
+        return 0x80;
       return 0x00;
     }
-
 
     void GearScreen_DrawAndShowItem(game::ItemId itemId, game::ui::Anim* emptyIdleAnim, u16 textId, int modelId) {
       game::MessageMgr mgr = game::MessageMgr::Instance();
       game::ui::ScreenContext& sctx = game::ui::GetScreenContext();
-      
+
       game::GiveItem(itemId);
-          
-     int iconId = util::GetPointer<int(game::ItemId)>(0x601E18)(itemId);
-      
+
+      int iconId = util::GetPointer<int(game::ItemId)>(0x601E18)(itemId);
+
       util::GetPointer<void(game::ui::Anim*, int)>(0x601a1c)(emptyIdleAnim, iconId);
       util::GetPointer<void(game::ui::MessageWindow*, u16, int)>(0x1ccfe4)(mgr.message_window, textId, 0);
 

--- a/code/source/rnd/custom_screen.cpp
+++ b/code/source/rnd/custom_screen.cpp
@@ -11,8 +11,6 @@ namespace rnd {
         const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
         
         // Sixth Slot [5] of Inventory array is the Title deed slot. 17 [16] is letter to kafei?
-        /*GearScreen_DrawAndShowItem(game::ItemId::SwampTitleDeed, gearScreen->icon_event00_l->return_empty_idle_anim,
-                                     0x172B, 0x41);*/
         if (newButtons == (u32)game::pad::Button::R) {
 
           // Check what is in current slot.
@@ -22,27 +20,25 @@ namespace rnd {
             if (firstFoundItem == game::ItemId::None) {
               firstFoundItem = gExtSaveData.collectedTradeItems[i];
             }
-            if (GearScreen_LoopDeedsForward(gearScreen, i, firstFoundItem)) break;
+            if (GearScreen_LoopTradeItemsForward(gearScreen, i, firstFoundItem)) break;
           }
         } else if (newButtons == (u32)game::pad::Button::L) {
-          #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-              rnd::util::Print("%s: L button pressed!\n", __func__);	
-            #endif
-          for (int i = 5; i >= 0; i--) {
+          for (int i = 4; i >= 0; i--) {
             if (firstFoundItem == game::ItemId::None) {
               firstFoundItem = gExtSaveData.collectedTradeItems[i];
             }
-            
-          
-
+            if (GearScreen_LoopTradeItemsBackward(gearScreen, i, firstFoundItem)) break;
           }
         }
-          
+      } else if (gearScreen->cursorIndex == 2) {
+        #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+          rnd::util::Print("%s: Index 2!\n", __func__);	
+        #endif
       }
       return;
     }
 
-    bool GearScreen_LoopDeedsForward(game::ui::screens::GearScreen* gearScreen,int i, game::ItemId firstFoundItem) {
+    bool GearScreen_LoopTradeItemsForward(game::ui::screens::GearScreen* gearScreen,int i, game::ItemId firstFoundItem) {
       auto& items = game::GetCommonData().save.inventory.items;
       int textId;
       int modelId;
@@ -71,6 +67,44 @@ namespace rnd {
                                 textId, modelId);
         return true;
       } else if (i == 4 && firstFoundItem != game::ItemId::None) {
+        textId = GearScreen_GetTextIdFromItemId(firstFoundItem);
+        modelId = GearScreen_GetModelIdFromItemId(firstFoundItem);
+        GearScreen_DrawAndShowItem(firstFoundItem , gearScreen->icon_event00_l->return_empty_idle_anim,
+                                textId, modelId);
+        return true;
+      }
+      return false;
+    }
+
+    bool GearScreen_LoopTradeItemsBackward(game::ui::screens::GearScreen* gearScreen,int i, game::ItemId firstFoundItem) {
+      auto& items = game::GetCommonData().save.inventory.items;
+      int textId;
+      int modelId;
+      
+      // Base case, if we have a none item, give the first available item.
+      if (items[5] == game::ItemId::None && gExtSaveData.collectedTradeItems[i] != game::ItemId::None) {
+        textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
+                                textId, modelId);
+        return true;
+      }
+      // Second case - we're not the last element and we contain an item, then swap that item.
+      if (i != 0 && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
+          (int)items[5] > (int)gExtSaveData.collectedTradeItems[i]) {
+        textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
+                                textId, modelId);
+        return true;
+      } else if (i == 0 && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
+        gExtSaveData.collectedTradeItems[i] != items[5]) {
+        textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
+                                textId, modelId);
+        return true;
+      } else if (i == 0 && firstFoundItem != game::ItemId::None) {
         textId = GearScreen_GetTextIdFromItemId(firstFoundItem);
         modelId = GearScreen_GetModelIdFromItemId(firstFoundItem);
         GearScreen_DrawAndShowItem(firstFoundItem , gearScreen->icon_event00_l->return_empty_idle_anim,

--- a/code/source/rnd/custom_screen.cpp
+++ b/code/source/rnd/custom_screen.cpp
@@ -1,0 +1,127 @@
+#include "rnd/custom_screen.h"
+
+namespace rnd {
+
+  namespace gearscreen {
+
+    extern "C" void GearScreen_GetStoredTradeItem(game::ui::screens::GearScreen* gearScreen) {
+      if (gearScreen->cursorIndex == 0) {
+        auto* gctx = rnd::GetContext().gctx;
+        game::ItemId firstFoundItem = game::ItemId::None;
+        const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
+        
+        // Sixth Slot [5] of Inventory array is the Title deed slot. 17 [16] is letter to kafei?
+        /*GearScreen_DrawAndShowItem(game::ItemId::SwampTitleDeed, gearScreen->icon_event00_l->return_empty_idle_anim,
+                                     0x172B, 0x41);*/
+        if (newButtons == (u32)game::pad::Button::R) {
+
+          // Check what is in current slot.
+          // After receiving value, check array from 0-4 to see what items we have obtained.
+          // We always know the order of the array, MoonsTear -> Land Title -> Swamp -> Mountain -> Ocean
+          for (int i = 0; i < 5; i++) {
+            if (firstFoundItem == game::ItemId::None) {
+              firstFoundItem = gExtSaveData.collectedTradeItems[i];
+            }
+            if (GearScreen_LoopDeedsForward(gearScreen, i, firstFoundItem)) break;
+          }
+        } else if (newButtons == (u32)game::pad::Button::L) {
+          #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+              rnd::util::Print("%s: L button pressed!\n", __func__);	
+            #endif
+          for (int i = 5; i >= 0; i--) {
+            if (firstFoundItem == game::ItemId::None) {
+              firstFoundItem = gExtSaveData.collectedTradeItems[i];
+            }
+            
+          
+
+          }
+        }
+          
+      }
+      return;
+    }
+
+    bool GearScreen_LoopDeedsForward(game::ui::screens::GearScreen* gearScreen,int i, game::ItemId firstFoundItem) {
+      auto& items = game::GetCommonData().save.inventory.items;
+      int textId;
+      int modelId;
+      
+      // Base case, if we have a none item, give the first available item.
+      if (items[5] == game::ItemId::None && gExtSaveData.collectedTradeItems[i] != game::ItemId::None) {
+        textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
+                                textId, modelId);
+        return true;
+      }
+      // Second case - we're not the last element and we contain an item, then swap that item.
+      if (i != 4 && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
+          (int)items[5] < (int)gExtSaveData.collectedTradeItems[i]) {
+        textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
+                                textId, modelId);
+        return true;
+      } else if (i == 4 && gExtSaveData.collectedTradeItems[i] != game::ItemId::None &&
+        gExtSaveData.collectedTradeItems[i] != items[5]) {
+        textId = GearScreen_GetTextIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        modelId = GearScreen_GetModelIdFromItemId(gExtSaveData.collectedTradeItems[i]);
+        GearScreen_DrawAndShowItem(gExtSaveData.collectedTradeItems[i] , gearScreen->icon_event00_l->return_empty_idle_anim,
+                                textId, modelId);
+        return true;
+      } else if (i == 4 && firstFoundItem != game::ItemId::None) {
+        textId = GearScreen_GetTextIdFromItemId(firstFoundItem);
+        modelId = GearScreen_GetModelIdFromItemId(firstFoundItem);
+        GearScreen_DrawAndShowItem(firstFoundItem , gearScreen->icon_event00_l->return_empty_idle_anim,
+                                textId, modelId);
+        return true;
+      }
+      return false;
+    }
+
+    int GearScreen_GetTextIdFromItemId(game::ItemId itemId) {
+      // Since we're limited on what items we got, just hard code these.
+      if (itemId == game::ItemId::MoonTear) return 0x1728;
+      else if (itemId == game::ItemId::LandTitleDeed) return 0x1729; 
+      else if (itemId == game::ItemId::SwampTitleDeed) return 0x172A; 
+      else if (itemId == game::ItemId::MountainTitleDeed) return 0x172B; 
+      else if (itemId == game::ItemId::OceanTitleDeed) return 0x172C; 
+      else if (itemId == game::ItemId::LetterToKafei) return 0x172F; 
+      else if (itemId == game::ItemId::PendantOfMemories) return 0x1730;
+      return 0x00;
+    }
+
+    int GearScreen_GetModelIdFromItemId(game::ItemId itemId) {
+      // Since we're limited on what items we got, just hard code these.
+      if (itemId == game::ItemId::MoonTear) return 0x59;
+      else if (itemId == game::ItemId::LandTitleDeed) return 0x5A; 
+      else if (itemId == game::ItemId::SwampTitleDeed) return 0x40; 
+      else if (itemId == game::ItemId::MountainTitleDeed) return 0x41; 
+      else if (itemId == game::ItemId::OceanTitleDeed) return 0x43; 
+      else if (itemId == game::ItemId::LetterToKafei) return 0x40; 
+      else if (itemId == game::ItemId::PendantOfMemories) return 0x00;
+      return 0x00;
+    }
+
+
+    void GearScreen_DrawAndShowItem(game::ItemId itemId, game::ui::Anim* emptyIdleAnim, u16 textId, int modelId) {
+      game::MessageMgr mgr = game::MessageMgr::Instance();
+      game::ui::ScreenContext& sctx = game::ui::GetScreenContext();
+      
+      game::GiveItem(itemId);
+          
+     int iconId = util::GetPointer<int(game::ItemId)>(0x601E18)(itemId);
+      
+      util::GetPointer<void(game::ui::Anim*, int)>(0x601a1c)(emptyIdleAnim, iconId);
+      util::GetPointer<void(game::ui::MessageWindow*, u16, int)>(0x1ccfe4)(mgr.message_window, textId, 0);
+
+      int modelType = util::GetPointer<int(game::ui::Anim*)>(0x6120e4)(emptyIdleAnim);
+      modelType = modelType + 0x1700;
+      util::GetPointer<void(game::ui::Context*, int)>(0x5a1aac)(sctx.ctx, modelId);
+      game::sound::PlayEffect(game::sound::EffectId::NA_SE_SY_CURSOR);
+      return;
+    }
+  }  // namespace gearscreen
+
+}  // namespace rnd

--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -348,4 +348,36 @@ namespace rnd {
     rnd::util::GetPointer<void(game::GlobalContext*, int)>(0x222BCC)(rnd::GetContext().gctx, 0);
   }
 
+  void ItemEffect_GiveTradeItem(game::CommonData* comData, s16 mask, s16 arg2) {
+    switch (mask) {
+      case 0: // Moon's Tear
+        gExtSaveData.collectedTradeItems[0] = game::ItemId::MoonTear;
+        break;
+      case 1: // Town Title Deed
+        gExtSaveData.collectedTradeItems[1] = game::ItemId::LandTitleDeed;
+        break;
+      case 2: // Swamp Title Deed
+        gExtSaveData.collectedTradeItems[2] = game::ItemId::SwampTitleDeed;
+        break;
+      case 3: // Mtn Title Deed
+        gExtSaveData.collectedTradeItems[3] = game::ItemId::MountainTitleDeed;
+        break;
+      case 4: // Ocean Title Deed
+        gExtSaveData.collectedTradeItems[4] = game::ItemId::OceanTitleDeed;
+        break;
+      case 5: // Room Key
+        gExtSaveData.collectedTradeItems[5] = game::ItemId::RoomKey;
+        break;
+      case 6: // Letter To Kafei
+        gExtSaveData.collectedTradeItems[6] = game::ItemId::LetterToKafei;
+        break;
+      case 7: // Pendant
+        gExtSaveData.collectedTradeItems[7] = game::ItemId::PendantOfMemories;
+        break;
+      case 8: // Letter To Mama
+        gExtSaveData.collectedTradeItems[8] = game::ItemId::LetterToMama;
+        break;
+    }
+  }
+
 }  // namespace rnd

--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -350,33 +350,33 @@ namespace rnd {
 
   void ItemEffect_GiveTradeItem(game::CommonData* comData, s16 mask, s16 arg2) {
     switch (mask) {
-      case 0: // Moon's Tear
-        gExtSaveData.collectedTradeItems[0] = game::ItemId::MoonTear;
-        break;
-      case 1: // Town Title Deed
-        gExtSaveData.collectedTradeItems[1] = game::ItemId::LandTitleDeed;
-        break;
-      case 2: // Swamp Title Deed
-        gExtSaveData.collectedTradeItems[2] = game::ItemId::SwampTitleDeed;
-        break;
-      case 3: // Mtn Title Deed
-        gExtSaveData.collectedTradeItems[3] = game::ItemId::MountainTitleDeed;
-        break;
-      case 4: // Ocean Title Deed
-        gExtSaveData.collectedTradeItems[4] = game::ItemId::OceanTitleDeed;
-        break;
-      case 5: // Room Key
-        gExtSaveData.collectedTradeItems[5] = game::ItemId::RoomKey;
-        break;
-      case 6: // Letter To Kafei
-        gExtSaveData.collectedTradeItems[6] = game::ItemId::LetterToKafei;
-        break;
-      case 7: // Pendant
-        gExtSaveData.collectedTradeItems[7] = game::ItemId::PendantOfMemories;
-        break;
-      case 8: // Letter To Mama
-        gExtSaveData.collectedTradeItems[8] = game::ItemId::LetterToMama;
-        break;
+    case 0:  // Moon's Tear
+      gExtSaveData.collectedTradeItems[0] = game::ItemId::MoonTear;
+      break;
+    case 1:  // Town Title Deed
+      gExtSaveData.collectedTradeItems[1] = game::ItemId::LandTitleDeed;
+      break;
+    case 2:  // Swamp Title Deed
+      gExtSaveData.collectedTradeItems[2] = game::ItemId::SwampTitleDeed;
+      break;
+    case 3:  // Mtn Title Deed
+      gExtSaveData.collectedTradeItems[3] = game::ItemId::MountainTitleDeed;
+      break;
+    case 4:  // Ocean Title Deed
+      gExtSaveData.collectedTradeItems[4] = game::ItemId::OceanTitleDeed;
+      break;
+    case 5:  // Room Key
+      gExtSaveData.collectedTradeItems[5] = game::ItemId::RoomKey;
+      break;
+    case 6:  // Letter To Kafei
+      gExtSaveData.collectedTradeItems[6] = game::ItemId::LetterToKafei;
+      break;
+    case 7:  // Pendant
+      gExtSaveData.collectedTradeItems[7] = game::ItemId::PendantOfMemories;
+      break;
+    case 8:  // Letter To Mama
+      gExtSaveData.collectedTradeItems[8] = game::ItemId::LetterToMama;
+      break;
     }
   }
 

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -614,12 +614,12 @@ namespace rnd {
         rnd::util::Print("%s: Active item row item ID is %#04x\n", __func__, rActiveItemRow->itemId);
 #endif
         // Only set if we're not a trade item or bottled item.
-        if ((rActiveItemRow->itemId < 0x12 && rActiveItemRow->itemId > 0x30) && (rActiveItemRow->itemId < 0x9F)) {
+        /*if ((rActiveItemRow->itemId < 0x12 && rActiveItemRow->itemId > 0x30) && (rActiveItemRow->itemId < 0x9F)) {
           // XXX: Hacky fix but maybe we need to redo how we track chests. Mark Giant's Mask Chest
           // to be repeatably obtainable since we're not extending this array to 126 in the second dimension.
           if (rActiveItemOverride.key.flag < 0x20)
             gExtSaveData.chestRewarded[rActiveItemOverride.key.scene][rActiveItemOverride.key.flag] = 1;
-        }
+        }*/
       }
       game::GlobalContext* gctx = GetContext().gctx;
       u16 textId = rActiveItemRow->textId;
@@ -665,13 +665,20 @@ namespace rnd {
       ItemOverride_Clear();
       player->get_item_id = incomingGetItemId;
       return;
-    } else if (override.key.type == ItemOverride_Type::OVR_CHEST &&
-               gExtSaveData.chestRewarded[override.key.scene][override.key.flag] == 1) {
+    } else if (override.key.type == ItemOverride_Type::OVR_CHEST /*&&
+               gExtSaveData.chestRewarded[override.key.scene][override.key.flag] == 1*/) {
       // Override was already given, check to see if we're a refill item now, if not, give a blue rupee instead.
       // Only do this for items that are not bottle refills.
       // Bottle logic is taken care of in the ItemUpgrade function.
-      override.value.getItemId = 0x02;
-      override.value.looksLikeItemId = 0x02;
+      // TODO: Check if we have the item in our inventory. If not, give the item back.
+      ItemRow* itemToBeGiven = ItemTable_GetItemRow(override.value.getItemId);
+      if (itemToBeGiven->itemId < 0x4A && game::HasItem((game::ItemId)itemToBeGiven->itemId)) {
+        override.value.getItemId = 0x02;
+        override.value.looksLikeItemId = 0x02;
+      } else if (itemToBeGiven->itemId == 0xFF) {
+        override.value.getItemId = 0x02;
+        override.value.looksLikeItemId = 0x02;
+      }
     }
 
     // This check is mainly to ensure we do not have repeatable progressive items within these base items.

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -729,10 +729,16 @@ namespace rnd {
   void ItemOverride_GetFairyRewardItem(game::GlobalContext* gctx, game::act::GreatFairy* fromActor,
                                        s16 incomingItemId) {
     int fairyEntrance = game::GetCommonData().sub1.entrance;
-    if (fairyEntrance == 0x4600 && gExtSaveData.fairyRewards.nct != 1) {
-      gExtSaveData.fairyRewards.nct = 1;
-      ItemOverride_PushPendingFairyRewardItem(gctx, fromActor, 0x86);
-      ItemOverride_PushPendingFairyRewardItem(gctx, fromActor, 0x0E);
+    if (fairyEntrance == 0x4600) {
+      if (gExtSaveData.fairyRewards.nct == 0) {
+        ItemOverride_PushPendingFairyRewardItem(gctx, fromActor, 0x0E);
+        gExtSaveData.fairyRewards.nct = 1;
+        return;
+      } else if (gExtSaveData.fairyRewards.nct == 1 && game::HasMask(game::ItemId::DekuMask)) {
+        ItemOverride_PushPendingFairyRewardItem(gctx, fromActor, 0x86);
+        gExtSaveData.fairyRewards.nct = 2;
+        return;
+      }
       return;
     } else if (fairyEntrance == 0x4610 && gExtSaveData.fairyRewards.woodfall != 1) {
       gExtSaveData.fairyRewards.woodfall = 1;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -613,10 +613,10 @@ namespace rnd {
   void ItemOverride_GetItemTextAndItemID(game::act::Player* actor) {
     if (rActiveItemRow != NULL) {
       if (rActiveItemOverride.key.type == ItemOverride_Type::OVR_CHEST) {
-        // Check and see if we have trade items or repeatable bottles and add to the array.
-        #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-          rnd::util::Print("%s: Active item row item ID is %#04x\n", __func__, rActiveItemRow->itemId);	
-        #endif
+// Check and see if we have trade items or repeatable bottles and add to the array.
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+        rnd::util::Print("%s: Active item row item ID is %#04x\n", __func__, rActiveItemRow->itemId);
+#endif
         // Only set if we're not a trade item or bottled item.
         if ((rActiveItemRow->itemId < 0x12 && rActiveItemRow->itemId > 0x30) && (rActiveItemRow->itemId < 0x9F)) {
           // XXX: Hacky fix but maybe we need to redo how we track chests. Mark Giant's Mask Chest
@@ -921,9 +921,9 @@ namespace rnd {
   }
 
   void DebugStatement(game::ItemId curItemSlot) {
-    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s: Current item slot is %#04x\n", __func__, curItemSlot);	
-    #endif
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Current item slot is %#04x\n", __func__, curItemSlot);
+#endif
   }
   }
 }  // namespace rnd

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -45,8 +45,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6F;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0xAB;
-    rItemOverrides[1].value.looksLikeItemId = 0xAB;
+    rItemOverrides[1].value.getItemId = 0xA1;
+    rItemOverrides[1].value.looksLikeItemId = 0xA1;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;
@@ -614,7 +614,11 @@ namespace rnd {
     if (rActiveItemRow != NULL) {
       if (rActiveItemOverride.key.type == ItemOverride_Type::OVR_CHEST) {
         // Check and see if we have trade items or repeatable bottles and add to the array.
-        if (rActiveItemRow->itemId < 0x28 || (rActiveItemRow->itemId > 0x30 && rActiveItemRow->itemId < 0x9f)) {
+        #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+          rnd::util::Print("%s: Active item row item ID is %#04x\n", __func__, rActiveItemRow->itemId);	
+        #endif
+        // Only set if we're not a trade item or bottled item.
+        if ((rActiveItemRow->itemId < 0x12 && rActiveItemRow->itemId > 0x30) && (rActiveItemRow->itemId < 0x9F)) {
           // XXX: Hacky fix but maybe we need to redo how we track chests. Mark Giant's Mask Chest
           // to be repeatably obtainable since we're not extending this array to 126 in the second dimension.
           if (rActiveItemOverride.key.flag < 0x20)
@@ -659,9 +663,7 @@ namespace rnd {
       player->get_item_id = incomingGetItemId;
       return;
     } else if (override.key.type == ItemOverride_Type::OVR_CHEST &&
-               gExtSaveData.chestRewarded[override.key.scene][override.key.flag] == 1 &&
-               (override.value.getItemId != 0x60 || override.value.getItemId != 0x6A ||
-                (override.value.getItemId < 0x6E && override.value.getItemId > 0x70))) {
+               gExtSaveData.chestRewarded[override.key.scene][override.key.flag] == 1) {
       // Override was already given, check to see if we're a refill item now, if not, give a blue rupee instead.
       // Only do this for items that are not bottle refills.
       // Bottle logic is taken care of in the ItemUpgrade function.
@@ -916,6 +918,12 @@ namespace rnd {
 
   u32 ItemOverride_GetOshExtData() {
     return (u32)gExtSaveData.givenItemChecks.enOshGivenItem;
+  }
+
+  void DebugStatement(game::ItemId curItemSlot) {
+    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: Current item slot is %#04x\n", __func__, curItemSlot);	
+    #endif
   }
   }
 }  // namespace rnd

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -45,8 +45,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6F;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0xB4;
-    rItemOverrides[1].value.looksLikeItemId = 0xB4;
+    rItemOverrides[1].value.getItemId = 0x01;
+    rItemOverrides[1].value.looksLikeItemId = 0x01;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -44,9 +44,9 @@ namespace rnd {
     rItemOverrides[0].value.getItemId = 0x26;
     rItemOverrides[0].value.looksLikeItemId = 0x26;
     rItemOverrides[1].key.scene = 0x6F;
-    rItemOverrides[1].key.type = ItemOverride_Type::OVR_CHEST;
-    rItemOverrides[1].value.getItemId = 0x32;
-    rItemOverrides[1].value.looksLikeItemId = 0x32;
+    rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
+    rItemOverrides[1].value.getItemId = 0xAB;
+    rItemOverrides[1].value.looksLikeItemId = 0xAB;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -891,21 +891,21 @@ namespace rnd {
 
       [0xAE] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map, 0x6137, 0x000A0,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveDungeonItem, (s16)3, (s16)0),  // Map (Woodfall)
 
       [0xAF] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map, 0x6138, 0x000A0,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveDungeonItem, (s16)3, (s16)1),  // Map (Snowhead)
 
       [0xB0] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map, 0x6139, 0x000A0,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveDungeonItem, (s16)3, (s16)2),  // Map (Great Bay)
 
       [0xB1] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Map, 0x613A, 0x000A0,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveDungeonItem, (s16)3,
                         (s16)3),  // Map (Stone Tower)
 
@@ -919,32 +919,32 @@ namespace rnd {
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMagic, (s16)-1, (s16)-1),  // Small Magic
 
       [0xB4] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B4,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Clocktown
 
       [0xB5] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B5,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Woodfall
 
       [0xB6] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B6,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Snowhead
 
       [0xB7] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B7,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Romani Ranch
 
       [0xB8] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B8,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Great Bay
 
       [0xB9] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B9,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_MAP,
+                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Map of Stone Tower
 

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -918,35 +918,41 @@ namespace rnd {
                         0x000C8, 0x000A4, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, 0xFF,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveMagic, (s16)-1, (s16)-1),  // Small Magic
 
-      [0xB4] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B4,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Map of Clocktown
+      [0xB4] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B4, 0x024D,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Map of Clocktown
 
-      [0xB5] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B5,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Map of Woodfall
+      [0xB5] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B5, 0x024D,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Map of Woodfall
 
-      [0xB6] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B6,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Map of Snowhead
+      [0xB6] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B6, 0x024D,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Map of Snowhead
 
-      [0xB7] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B7,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Map of Romani Ranch
+      [0xB7] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B7, 0x024D,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Map of Romani Ranch
 
-      [0xB8] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B8,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Map of Great Bay
+      [0xB8] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B8, 0x024D,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Map of Great Bay
 
-      [0xB9] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B9,
-                        0x024D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Map of Stone Tower
+      [0xB9] =
+          ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::MapUnused, 0x00B9, 0x024D,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DUNGEON_MAP_MAYBE,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Map of Stone Tower
 
       [0xBA] =
           ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::WOODEN_SMALL, (u8)game::ItemId::FishingPass, 0x00CF,

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -622,120 +622,112 @@ namespace rnd {
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSmallKey, (s16)1,
                         (s16)-1),  // Small Key (Snowhead)
 
-      [0x78] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::DekuMask, 0x0078, 0x01BD,
+      [0x78] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DekuMask, 0x0078, 0x01BD,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Deku Mask
 
-      [0x79] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronMask, 0x0079,
-                        0x0119, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GORON_MASK,
+      [0x79] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronMask, 0x0079, 0x0119,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GORON_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Goron Mask
 
-      [0x7A] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::ZoraMask, 0x007A, 0x011A,
+      [0x7A] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ZoraMask, 0x007A, 0x011A,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ZORA_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Zora Mask
 
-      [0x7B] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::FierceDeityMask, 0x007B,
-                        0x0242, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_FIERCE_DEITY_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Fierce Deity Mask
+      [0x7B] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::FierceDeityMask, 0x007B, 0x0242,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_FIERCE_DEITY_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Fierce Deity Mask
 
-      [0x7C] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::CaptainHat, 0x007C, 0x0102,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_CAPTAINS_HAT,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Captain Hat
+      [0x7C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CaptainHat, 0x007C, 0x0102,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_CAPTAINS_HAT,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Captain Hat
 
-      [0x7D] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GiantMask, 0x007D, 0x0226,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIANTS_MASK,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Giant Mask
+      [0x7D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GiantMask, 0x007D, 0x0226,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIANTS_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Giant Mask
 
       [0x7E] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::AllNightMask, 0x007E, 0x0265,
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::AllNightMask, 0x007E, 0x0265,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ALL_NIGHT_MASK,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                    (s16)-1),  // All Night Mask
 
-      [0x7F] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::BunnyHood, 0x007F,
-                        0x0103, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BUNNY_HOOD,
+      [0x7F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BunnyHood, 0x007F, 0x0103,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BUNNY_HOOD,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bunny Hood
 
-      [0x80] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::KeatonMask, 0x0080, 0x0100,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KEATON_MASK,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Keaton Mask
+      [0x80] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KeatonMask, 0x0080, 0x0100,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KEATON_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Keaton Mask
 
-      [0x81] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GaroMask, 0x0081, 0x0209,
+      [0x81] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GaroMask, 0x0081, 0x0209,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GARO_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Garo Mask
 
-      [0x82] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::RomaniMask, 0x0082, 0x021F,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ROMANIS_MASK,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Romani Mask
+      [0x82] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RomaniMask, 0x0082, 0x021F,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ROMANIS_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Romani Mask
 
-      [0x83] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::CircusLeaderMask, 0x0083,
+      [0x83] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CircusLeaderMask, 0x0083,
                         0x0259, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
                         (s32)DrawGraphicItemID::DI_CIRCUS_LEADER_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
                         ItemEffect_None, (s16)-1,
                         (s16)-1),  // Circus Leader Mask
 
-      [0x84] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::PostmanHat, 0x0084, 0x0225,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_POSTMANS_HAT,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Postman Hat
+      [0x84] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PostmanHat, 0x0084, 0x0225,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_POSTMANS_HAT,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Postman Hat
 
-      [0x85] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::CoupleMask, 0x0085, 0x0282,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_COUPLES_MASK,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Couple's Mask
+      [0x85] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CoupleMask, 0x0085, 0x0282,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_COUPLES_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Couple's Mask
 
-      [0x86] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GreatFairyMask, 0x0086,
-                        0x020A, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
-                        (s32)DrawGraphicItemID::DI_GREAT_FAIRY_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1,
-                        (s16)-1),  // Great Fairy's Mask
+      [0x86] =
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GreatFairyMask, 0x0086, 0x020A,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GREAT_FAIRY_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (s16)-1),  // Great Fairy's Mask
 
-      [0x87] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GibdoMask, 0x0087,
-                        0x020B, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIBDO_MASK,
+      [0x87] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GibdoMask, 0x0087, 0x020B,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIBDO_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Gibdo's Mask
 
       [0x88] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::DonGeroMask, 0x0088, 0x0266,
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DonGeroMask, 0x0088, 0x0266,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DON_GERO_MASK,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Don Gero's Mask
 
-      [0X89] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::KamaroMask, 0x0089, 0x027D,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAMARO_MASK,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Kamaro's Mask
+      [0X89] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KamaroMask, 0x0089, 0x027D,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAMARO_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Kamaro's Mask
 
       [0x8A] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfTruth, 0x008A, 0x0104,
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfTruth, 0x008A, 0x0104,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MASK_OF_TRUTH,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Mask of Truth
 
-      [0x8B] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::StoneMask, 0x008B,
-                        0x0254, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_STONE_MASK,
+      [0x8B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::StoneMask, 0x008B, 0x0254,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_STONE_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Stone Mask
 
-      [0x8C] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::BremenMask, 0x008C, 0x025A,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BREMEN_MASK,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bremen Mask
+      [0x8C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BremenMask, 0x008C, 0x025A,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BREMEN_MASK,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bremen Mask
 
-      [0x8D] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::BlastMask, 0x008D,
-                        0x026D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BLAST_MASK,
+      [0x8D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BlastMask, 0x008D, 0x026D,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BLAST_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Blast Mask
 
       [0x8E] =
-          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfScents, 0x008E, 0x027E,
+          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfScents, 0x008E, 0x027E,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MASK_OF_SCENTS,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                    (s16)-1),  // Mask Of Scents
 
-      [0x8F] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::KafeiMask, 0x008F,
-                        0x0258, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAFEI_MASK,
+      [0x8F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KafeiMask, 0x008F, 0x0258,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAFEI_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Kafei Mask
 
       [0x90] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL, (u8)game::ItemId::SmallKey, 0x6135,

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -767,29 +767,29 @@ namespace rnd {
       // TODO: Trade quest items
       [0x96] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MoonTear, 0x0096, 0x01B1,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MOONS_TEAR,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Moon's Tear
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveTradeItem, (s16)0, (s16)-1),  // Moon's Tear
 
       [0x97] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LandTitleDeed, 0x0097, 0x01B2,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_TOWN_TITLE_DEED,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveTradeItem, (s16)1,
                    (s16)-1),  // Land Title Deed
 
       [0x98] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SwampTitleDeed, 0x0098, 0x01B2,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_SWAMP_TITLE_DEED,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveTradeItem, (s16)2,
                    (s16)-1),  // Swamp Title Deed
 
       [0x99] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MountainTitleDeed, 0x0099,
                         0x01B2, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
                         (s32)DrawGraphicItemID::DI_MOUNTAIN_TITLE_DEED, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Mountain Title Deed
+                        ItemEffect_GiveTradeItem, (s16)3, (s16)-1),  // Mountain Title Deed
 
       [0x9A] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::OceanTitleDeed, 0x009A, 0x01B2,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_OCEAN_TITLE_DEED,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveTradeItem, (s16)4,
                    (s16)-1),  // Ocean Title Deed
 
       [0x9B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GreatFairySword, 0x009B,
@@ -820,12 +820,12 @@ namespace rnd {
 
       [0xA0] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RoomKey, 0x00A0, 0x020F,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ROOM_KEY,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Room Key
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveTradeItem, (s16)5, (s16)-1),  // Room Key
 
       [0xA1] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LetterToMama, 0x00A1, 0x0245,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MAMAS_LETTER,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveTradeItem, (s16)8,
                    (s16)-1),  // Letter To Mama
 
       [0xA2] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL, (u8)game::ItemId::SmallKey, 0x6136,
@@ -871,13 +871,13 @@ namespace rnd {
       [0xAA] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::LetterToKafei, 0x00AA, 0x0210,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_LETTER_TO_KAFEI,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveTradeItem, (s16)6,
                    (s16)-1),  // Letter To Kafei
 
       [0xAB] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PendantOfMemories, 0x00AB,
                         0x0215, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
                         (s32)DrawGraphicItemID::DI_PENDANT_OF_MEMORIES, (rnd::upgradeFunc)ItemUpgrade_None,
-                        ItemEffect_None, (s16)-1, (s16)-1),  // Pendant Of Memories
+                        ItemEffect_GiveTradeItem, (s16)7, (s16)-1),  // Pendant Of Memories
 
       [0xAC] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::DECORATED_BIG, (u8)game::ItemId::Compass, 0x613D,
                         0x00091, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_COMPASS,

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -472,7 +472,7 @@ namespace rnd {
 
       [0x59] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::HookshotUnused, 0x0059, 0x00196,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_RED_POTION,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_RED_POTION,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)3,
                    (s16)-1),  // Red Potion?
 
@@ -552,7 +552,7 @@ namespace rnd {
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bottle With Zora Egg
 
       [0x6A] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoldDust, 0x006A, 0x01E9,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_DUST,
+                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_GOLD_DUST,
                         (rnd::upgradeFunc)ItemUpgrade_RefillBottle, ItemEffect_None, (s16)-1,
                         (s16)-1),  // Bottle With Gold Dust
 
@@ -622,112 +622,120 @@ namespace rnd {
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSmallKey, (s16)1,
                         (s16)-1),  // Small Key (Snowhead)
 
-      [0x78] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DekuMask, 0x0078, 0x01BD,
+      [0x78] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::DekuMask, 0x0078, 0x01BD,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DEKU_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Deku Mask
 
-      [0x79] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronMask, 0x0079, 0x0119,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GORON_MASK,
+      [0x79] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronMask, 0x0079,
+                        0x0119, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GORON_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Goron Mask
 
-      [0x7A] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::ZoraMask, 0x007A, 0x011A,
+      [0x7A] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::ZoraMask, 0x007A, 0x011A,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ZORA_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Zora Mask
 
-      [0x7B] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::FierceDeityMask, 0x007B, 0x0242,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_FIERCE_DEITY_MASK,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                   (s16)-1),  // Fierce Deity Mask
+      [0x7B] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::FierceDeityMask, 0x007B,
+                        0x0242, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_FIERCE_DEITY_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1,
+                        (s16)-1),  // Fierce Deity Mask
 
-      [0x7C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CaptainHat, 0x007C, 0x0102,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_CAPTAINS_HAT,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Captain Hat
+      [0x7C] =
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::CaptainHat, 0x007C, 0x0102,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_CAPTAINS_HAT,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Captain Hat
 
-      [0x7D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GiantMask, 0x007D, 0x0226,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIANTS_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Giant Mask
+      [0x7D] =
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GiantMask, 0x007D, 0x0226,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIANTS_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Giant Mask
 
       [0x7E] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::AllNightMask, 0x007E, 0x0265,
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::AllNightMask, 0x007E, 0x0265,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ALL_NIGHT_MASK,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                    (s16)-1),  // All Night Mask
 
-      [0x7F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BunnyHood, 0x007F, 0x0103,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BUNNY_HOOD,
+      [0x7F] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::BunnyHood, 0x007F,
+                        0x0103, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BUNNY_HOOD,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bunny Hood
 
-      [0x80] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KeatonMask, 0x0080, 0x0100,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KEATON_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Keaton Mask
+      [0x80] =
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::KeatonMask, 0x0080, 0x0100,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KEATON_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Keaton Mask
 
-      [0x81] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GaroMask, 0x0081, 0x0209,
+      [0x81] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GaroMask, 0x0081, 0x0209,
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GARO_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Garo Mask
 
-      [0x82] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::RomaniMask, 0x0082, 0x021F,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ROMANIS_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Romani Mask
+      [0x82] =
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::RomaniMask, 0x0082, 0x021F,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_ROMANIS_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Romani Mask
 
-      [0x83] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CircusLeaderMask, 0x0083,
+      [0x83] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::CircusLeaderMask, 0x0083,
                         0x0259, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
                         (s32)DrawGraphicItemID::DI_CIRCUS_LEADER_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
                         ItemEffect_None, (s16)-1,
                         (s16)-1),  // Circus Leader Mask
 
-      [0x84] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::PostmanHat, 0x0084, 0x0225,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_POSTMANS_HAT,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Postman Hat
+      [0x84] =
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::PostmanHat, 0x0084, 0x0225,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_POSTMANS_HAT,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Postman Hat
 
-      [0x85] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::CoupleMask, 0x0085, 0x0282,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_COUPLES_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Couple's Mask
+      [0x85] =
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::CoupleMask, 0x0085, 0x0282,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_COUPLES_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Couple's Mask
 
-      [0x86] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GreatFairyMask, 0x0086, 0x020A,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GREAT_FAIRY_MASK,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                   (s16)-1),  // Great Fairy's Mask
+      [0x86] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GreatFairyMask, 0x0086,
+                        0x020A, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF,
+                        (s32)DrawGraphicItemID::DI_GREAT_FAIRY_MASK, (rnd::upgradeFunc)ItemUpgrade_None,
+                        ItemEffect_None, (s16)-1,
+                        (s16)-1),  // Great Fairy's Mask
 
-      [0x87] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GibdoMask, 0x0087, 0x020B,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIBDO_MASK,
+      [0x87] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::GibdoMask, 0x0087,
+                        0x020B, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GIBDO_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Gibdo's Mask
 
       [0x88] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::DonGeroMask, 0x0088, 0x0266,
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::DonGeroMask, 0x0088, 0x0266,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_DON_GERO_MASK,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Don Gero's Mask
 
-      [0X89] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KamaroMask, 0x0089, 0x027D,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAMARO_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Kamaro's Mask
+      [0X89] =
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::KamaroMask, 0x0089, 0x027D,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAMARO_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Kamaro's Mask
 
       [0x8A] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfTruth, 0x008A, 0x0104,
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfTruth, 0x008A, 0x0104,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MASK_OF_TRUTH,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Mask of Truth
 
-      [0x8B] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::StoneMask, 0x008B, 0x0254,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_STONE_MASK,
+      [0x8B] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::StoneMask, 0x008B,
+                        0x0254, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_STONE_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Stone Mask
 
-      [0x8C] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BremenMask, 0x008C, 0x025A,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BREMEN_MASK,
-                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bremen Mask
+      [0x8C] =
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::BremenMask, 0x008C, 0x025A,
+                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BREMEN_MASK,
+                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Bremen Mask
 
-      [0x8D] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::BlastMask, 0x008D, 0x026D,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BLAST_MASK,
+      [0x8D] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::BlastMask, 0x008D,
+                        0x026D, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BLAST_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Blast Mask
 
       [0x8E] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfScents, 0x008E, 0x027E,
+          ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::MaskOfScents, 0x008E, 0x027E,
                    (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_MASK_OF_SCENTS,
                    (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
                    (s16)-1),  // Mask Of Scents
 
-      [0x8F] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::KafeiMask, 0x008F, 0x0258,
-                        (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAFEI_MASK,
+      [0x8F] = ITEM_ROW((u32)GetItemID::GI_MASK_DEKU, ChestType::WOODEN_BIG, (u8)game::ItemId::KafeiMask, 0x008F,
+                        0x0258, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_KAFEI_MASK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Kafei Mask
 
       [0x90] = ITEM_ROW((u32)GetItemID::GI_RUPEE_BLUE, ChestType::DECORATED_SMALL, (u8)game::ItemId::SmallKey, 0x6135,
@@ -747,11 +755,10 @@ namespace rnd {
                         (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_MILK,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1, (s16)-1),  // Milk Refill
 
-      [0x93] =
-          ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoldDustFill, 0x0093, 0x001E8,
-                   (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_BOTTLE_GOLD_DUST,
-                   (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
-                   (s16)-1),  // Gold Dust Refill
+      [0x93] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoldDustFill, 0x0093,
+                        0x001E8, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s32)DrawGraphicItemID::DI_GOLD_DUST,
+                        (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_None, (s16)-1,
+                        (s16)-1),  // Gold Dust Refill
 
       [0x94] =
           ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::MysteryMilkFill, 0x00CE, 0x00B6,

--- a/code/source/rnd/item_upgrade.cpp
+++ b/code/source/rnd/item_upgrade.cpp
@@ -89,6 +89,11 @@ namespace rnd {
 
   GetItemID ItemUpgrade_RefillBottle(game::SaveData* saveCtx, GetItemID getItemId) {
     switch (getItemId) {
+    case GetItemID::GI_BOTTLE_POTION_RED:
+      if (gExtSaveData.givenItemChecks.bottleRedPotionGiven == 1) {
+        return GetItemID::GI_POTION_RED;
+      }
+      break;
     case GetItemID::GI_BOTTLE_MILK:
       if (gExtSaveData.givenItemChecks.bottleMilkGiven == 1) {
         return GetItemID::GI_BOTTLE_MILK_REFILL;

--- a/code/source/rnd/item_upgrade.cpp
+++ b/code/source/rnd/item_upgrade.cpp
@@ -88,6 +88,10 @@ namespace rnd {
   }
 
   GetItemID ItemUpgrade_RefillBottle(game::SaveData* saveCtx, GetItemID getItemId) {
+    // As you can see mystery milk avoids this check since it's wiped from your inventory
+    // on cycle reset. It also happens to remove whichever bottle the milk is in,
+    // so we should avoid refills and just give the bottle until a user can get that
+    // side quest fulfilled.
     switch (getItemId) {
     case GetItemID::GI_BOTTLE_POTION_RED:
       if (gExtSaveData.givenItemChecks.bottleRedPotionGiven == 1) {
@@ -115,11 +119,6 @@ namespace rnd {
     case GetItemID::GI_BOTTLE_CHATEAU_ROMANI:
       if (gExtSaveData.givenItemChecks.bottleChateuGiven == 1) {
         return GetItemID::GI_BOTTLE_CHATEAU_ROMANI_REFILL;
-      }
-      break;
-    case GetItemID::GI_BOTTLE_MYSTERY_MILK:
-      if (gExtSaveData.givenItemChecks.bottleMysteryMilkGiven == 1) {
-        return GetItemID::GI_BOTTLE_MYSTERY_MILK_REFILL;
       }
       break;
     default:

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -781,18 +781,22 @@ namespace rnd {
     memset(&gExtSaveData.chestRewarded, 0, sizeof(gExtSaveData.chestRewarded));
     memset(&gExtSaveData.scenesDiscovered, 0, sizeof(gExtSaveData.scenesDiscovered));
     memset(&gExtSaveData.itemCollected, 0, sizeof(gExtSaveData.itemCollected));
-    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        gExtSaveData.collectedTradeItems[0] = game::ItemId::MoonTear;
-        gExtSaveData.collectedTradeItems[1] = game::ItemId::LandTitleDeed;
-        gExtSaveData.collectedTradeItems[2] = game::ItemId::SwampTitleDeed;
-        gExtSaveData.collectedTradeItems[3] = game::ItemId::MountainTitleDeed;
-        gExtSaveData.collectedTradeItems[4] = game::ItemId::OceanTitleDeed;
-    #else
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    gExtSaveData.collectedTradeItems[0] = game::ItemId::MoonTear;
+    gExtSaveData.collectedTradeItems[1] = game::ItemId::LandTitleDeed;
+    gExtSaveData.collectedTradeItems[2] = game::ItemId::SwampTitleDeed;
+    gExtSaveData.collectedTradeItems[3] = game::ItemId::MountainTitleDeed;
+    gExtSaveData.collectedTradeItems[4] = game::ItemId::OceanTitleDeed;
+    gExtSaveData.collectedTradeItems[5] = game::ItemId::RoomKey;
+    gExtSaveData.collectedTradeItems[6] = game::ItemId::LetterToKafei;
+    gExtSaveData.collectedTradeItems[7] = game::ItemId::PendantOfMemories;
+    gExtSaveData.collectedTradeItems[8] = game::ItemId::LetterToMama;
+#else
     for (int i = 0; i < 9; i++) {
       gExtSaveData.collectedTradeItems[i] = game::ItemId::None;
     }
-    #endif
-    
+#endif
+
     // TODO: Settings options belong in ext.
     // memset(&gExtSaveData.entrancesDiscovered, 0, sizeof(gExtSaveData.entrancesDiscovered));
     // // Ingame Options

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -26,6 +26,7 @@ namespace rnd {
     saveData.anonymous_162 = saveData.anonymous_162 | 0x6000;
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::MaskOfTruth);
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::PictographBox);
+    rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::BlastMask);
     // rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::PowderKeg);
     // saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
     saveData.inventory.inventory_count_register.bomb_bag_upgrade = game::BombBag::BombBag40;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -3,9 +3,9 @@ extern "C" {
 }
 #include <string.h>
 #include "rnd/item_effect.h"
+#include "rnd/item_table.h"
 #include "rnd/savefile.h"
 #include "rnd/settings.h"
-#include "rnd/item_table.h"
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
 #include "common/debug.h"
 #endif
@@ -916,15 +916,23 @@ namespace rnd {
         firstItem = gExtSaveData.collectedTradeItems[i];
       }
       if (gidItemRow->itemId == (u8)gExtSaveData.collectedTradeItems[i]) {
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-            rnd::util::Print("%s: Found item %#04x in our array, setting to none.\n", __func__);	
-          #endif
-          gExtSaveData.collectedTradeItems[i] = game::ItemId::None;
+        gExtSaveData.collectedTradeItems[i] = game::ItemId::None;
       }
     }
     // Place the item in inventory, if there is no item to place it simply places none.
-    // game::SaveData& saveData = game::GetCommonData().save;
-    // saveData.inventory.items[slot] = firstItem;
+    game::SaveData& saveData = game::GetCommonData().save;
+    saveData.inventory.items[slot] = firstItem;
+  }
+  extern "C" void SaveFile_RemoveTradeItemFromSlot(u16 item, u8 slot) {
+    // This is a get item ID, we need to translate it to the regular item ID.
+    if (slot == 5) {
+      for (int i = 0; i < 4; i++) {
+        if (item == (u16)gExtSaveData.collectedTradeItems[i]) {
+          gExtSaveData.collectedTradeItems[i] = game::ItemId::None;
+          break;
+        }
+      }
+    }
   }
   // SaveFile_DrawAndShowUIMessage() {
 

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -704,6 +704,9 @@ namespace rnd {
     } else {
       // Player initially is given magic 0x30 on save creation. This prevents that.
       playerData.magic = 0x0;
+#ifdef ENABLE_DEBUG
+      playerData.magic = 0x30;
+#endif
     }
 
     if (gSettingsContext.startingDoubleDefense) {
@@ -781,7 +784,7 @@ namespace rnd {
     memset(&gExtSaveData.chestRewarded, 0, sizeof(gExtSaveData.chestRewarded));
     memset(&gExtSaveData.scenesDiscovered, 0, sizeof(gExtSaveData.scenesDiscovered));
     memset(&gExtSaveData.itemCollected, 0, sizeof(gExtSaveData.itemCollected));
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#ifdef ENABLE_DEBUG
     gExtSaveData.collectedTradeItems[0] = game::ItemId::MoonTear;
     gExtSaveData.collectedTradeItems[1] = game::ItemId::LandTitleDeed;
     gExtSaveData.collectedTradeItems[2] = game::ItemId::SwampTitleDeed;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -5,6 +5,7 @@ extern "C" {
 #include "rnd/item_effect.h"
 #include "rnd/savefile.h"
 #include "rnd/settings.h"
+#include "rnd/item_table.h"
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
 #include "common/debug.h"
 #endif
@@ -906,6 +907,25 @@ namespace rnd {
     extDataUnmount(fsa);
   }
 
+  extern "C" void SaveFile_RemoveStoredDeed(u16 item, u8 slot) {
+    // This is a get item ID, we need to translate it to the regular item ID.
+    ItemRow* gidItemRow = ItemTable_GetItemRowFromIndex(item);
+    game::ItemId firstItem = game::ItemId::None;
+    for (int i = 0; i < 4; i++) {
+      if (gidItemRow->itemId != (u8)gExtSaveData.collectedTradeItems[i] && firstItem == game::ItemId::None) {
+        firstItem = gExtSaveData.collectedTradeItems[i];
+      }
+      if (gidItemRow->itemId == (u8)gExtSaveData.collectedTradeItems[i]) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+            rnd::util::Print("%s: Found item %#04x in our array, setting to none.\n", __func__);	
+          #endif
+          gExtSaveData.collectedTradeItems[i] = game::ItemId::None;
+      }
+    }
+    // Place the item in inventory, if there is no item to place it simply places none.
+    // game::SaveData& saveData = game::GetCommonData().save;
+    // saveData.inventory.items[slot] = firstItem;
+  }
   // SaveFile_DrawAndShowUIMessage() {
 
   // }

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -107,7 +107,6 @@ namespace rnd {
     gSettingsContext.freeScarecrow = 1;
     saveData.activate_dungeon_skip_portal_0xF0_for_all = 0xF0;
     SaveFile_FillOverWorldMapData();
-
 #endif
     // TODO: Decomp event flags. Most likely in the large anonymous structs in the SaveData.
     u8 isNewFile = saveData.has_completed_intro;
@@ -782,6 +781,18 @@ namespace rnd {
     memset(&gExtSaveData.chestRewarded, 0, sizeof(gExtSaveData.chestRewarded));
     memset(&gExtSaveData.scenesDiscovered, 0, sizeof(gExtSaveData.scenesDiscovered));
     memset(&gExtSaveData.itemCollected, 0, sizeof(gExtSaveData.itemCollected));
+    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+        gExtSaveData.collectedTradeItems[0] = game::ItemId::None;
+        gExtSaveData.collectedTradeItems[1] = game::ItemId::LandTitleDeed;
+        gExtSaveData.collectedTradeItems[2] = game::ItemId::None;
+        gExtSaveData.collectedTradeItems[3] = game::ItemId::MountainTitleDeed;
+        gExtSaveData.collectedTradeItems[4] = game::ItemId::OceanTitleDeed;
+    #else
+    for (int i = 0; i < 9; i++) {
+      gExtSaveData.collectedTradeItems[i] = game::ItemId::None;
+    }
+    #endif
+    
     // TODO: Settings options belong in ext.
     // memset(&gExtSaveData.scenesDiscovered, 0, sizeof(gExtSaveData.scenesDiscovered));
     // memset(&gExtSaveData.entrancesDiscovered, 0, sizeof(gExtSaveData.entrancesDiscovered));
@@ -887,5 +898,9 @@ namespace rnd {
     extDataWriteFileDirectly(fsa, path, &gExtSaveData, 0, sizeof(gExtSaveData));
     extDataUnmount(fsa);
   }
+
+  // SaveFile_DrawAndShowUIMessage() {
+
+  // }
 
 }  // namespace rnd

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -782,9 +782,9 @@ namespace rnd {
     memset(&gExtSaveData.scenesDiscovered, 0, sizeof(gExtSaveData.scenesDiscovered));
     memset(&gExtSaveData.itemCollected, 0, sizeof(gExtSaveData.itemCollected));
     #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        gExtSaveData.collectedTradeItems[0] = game::ItemId::None;
+        gExtSaveData.collectedTradeItems[0] = game::ItemId::MoonTear;
         gExtSaveData.collectedTradeItems[1] = game::ItemId::LandTitleDeed;
-        gExtSaveData.collectedTradeItems[2] = game::ItemId::None;
+        gExtSaveData.collectedTradeItems[2] = game::ItemId::SwampTitleDeed;
         gExtSaveData.collectedTradeItems[3] = game::ItemId::MountainTitleDeed;
         gExtSaveData.collectedTradeItems[4] = game::ItemId::OceanTitleDeed;
     #else
@@ -794,7 +794,6 @@ namespace rnd {
     #endif
     
     // TODO: Settings options belong in ext.
-    // memset(&gExtSaveData.scenesDiscovered, 0, sizeof(gExtSaveData.scenesDiscovered));
     // memset(&gExtSaveData.entrancesDiscovered, 0, sizeof(gExtSaveData.entrancesDiscovered));
     // // Ingame Options
     // gExtSaveData.option_EnableBGM          = gSettingsContext.playMusic;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -211,7 +211,7 @@ namespace rnd {
     saveData.turtle_flags.skip_swimming_to_great_bay_temple_cutscene = 1;
 
     // Needs to be greater than zero to skip first time song of time cutscene
-    saveData.player.song_of_time_counter = 1;
+    saveData.player.three_day_reset_count = 1;
   }
 
   void SaveFile_SetFastAnimationFlags() {

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -28,6 +28,7 @@ namespace rnd {
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::MaskOfTruth);
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::PictographBox);
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::BlastMask);
+    rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::KafeiMask);
     // rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::PowderKeg);
     // saveData.inventory.inventory_count_register.quiver_upgrade = game::Quiver::Quiver50;
     saveData.inventory.inventory_count_register.bomb_bag_upgrade = game::BombBag::BombBag40;
@@ -913,20 +914,21 @@ namespace rnd {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     rnd::util::Print("%s: Item and slot are %#04x %u\n", __func__, item, slot);
 #endif
-    if (slot != 5 && slot != 17) return;
+    if (slot != 5 && slot != 17)
+      return;
     ItemRow* gidItemRow = ItemTable_GetItemRowFromIndex(item);
     game::ItemId firstItem = game::ItemId::None;
-    
+
     for (int i = 0; i < 9; i++) {
       if (gidItemRow->itemId != (u8)gExtSaveData.collectedTradeItems[i] && firstItem == game::ItemId::None) {
         if (slot == 17 && i > 5 && i < 8) {
-          #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
           rnd::util::Print("%s: Slot is 17 and our found item is %#04x\n", __func__,
                            gExtSaveData.collectedTradeItems[i]);
 #endif
           firstItem = gExtSaveData.collectedTradeItems[i];
         }
-          
+
         else if (slot == 5 && i < 5)
           firstItem = gExtSaveData.collectedTradeItems[i];
       }
@@ -951,7 +953,7 @@ namespace rnd {
   }
 
   extern "C" u8 SaveFile_GetItemCurrentlyInSlot(u8 slot) {
-    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
     rnd::util::Print("%s: Current slot is %#04x\n", __func__, game::GetCommonData().save.inventory.items[slot]);
 #endif
     return (u8)game::GetCommonData().save.inventory.items[slot];


### PR DESCRIPTION
This PR introduces a new feature to the randomizer - the ability to swap trade items on the gear screen. Upon collecting a trade item it will also store the value in an array in the ext data. A user will be able to swap through the moons tear/title deeds in the first slot, and the letter to kafei and pendant of memories in the items respective slot.

On playing song of time, the items will now remain in the inventory over Song Of Time reset. Upon giving an item away, it will also remove it from the ext data inventory as well. This should now resolve issue https://github.com/Z3DR/MM3D_Randomizer/issues/45.

This PR also includes a finalized fix of bottle logic. This new update should now properly respect bottle refills, and avoid giving users any more unnecessary bottles, or fail to give repeating bottles in chests.

This PR also includes a chest size modification that will change the chest size based on the type of item.