### PR TITLE
Fix Ocean Deed crashing game

### DIFF
--- a/code/mm.ld
+++ b/code/mm.ld
@@ -63,7 +63,7 @@ SECTIONS{
     *(.patch_KeepBowOnEpona)
   }
 
-  .patch_RemoveTradeItemFromSlot 0x1AFE8C : {
+  .patch_RemoveTradeItemFromSlot 0x1AFE94 : {
     *(.patch_RemoveTradeItemFromSlot)
   }
 

--- a/code/source/asm/trade_item_hooks.s
+++ b/code/source/asm/trade_item_hooks.s
@@ -29,7 +29,7 @@ hook_RemoveTradeItemFromExtSlot:
   push {r0-r12, lr}
   bl SaveFile_RemoveTradeItemFromSlot 
   pop {r0-r12, lr}
-  cpy r2,r1
+  cpy r4,r0
   bx lr
 
 .global hook_RemoveKafeiItemFromExtSlot

--- a/code/source/asm/trade_item_patches.s
+++ b/code/source/asm/trade_item_patches.s
@@ -3,7 +3,7 @@
 .section .patch_RemoveTradeItemFromSlot
 .global patch_RemoveTradeItemFromSlot
 patch_RemoveTradeItemFromSlot:
-  bleq hook_RemoveTradeItemFromExtSlot
+  bl hook_RemoveTradeItemFromExtSlot
 
 .section .patch_DoNotRemoveTradeItems
 .global patch_DoNotRemoveTradeItems

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -725,7 +725,7 @@ namespace rnd {
     // This is to ensure fairness and allows us to place these items without second guessing in logic.
     // Let's be a bit rude and give them fishing passes.
     // XXX: This may be simplified with the IsItemObtained checks as well.
-    if (override.value.getItemId > 0x45 || override.value.getItemId < 0x4A) {
+    if (override.value.getItemId > 0x45 && override.value.getItemId < 0x4A) {
       if (incomingGetItemId == (s16)GetItemID::GI_MOONS_TEAR &&
           gExtSaveData.givenItemChecks.enObjMoonStoneGivenItem == 1) {
         player->get_item_id = (s16)GetItemID::GI_FISHING_HOLE_PASS;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -891,9 +891,6 @@ namespace rnd {
   }
 
   extern "C" void SaveFile_SaveExtSaveData() {
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: Saving extdata.\n", __func__);
-#endif
     game::CommonData& comData = game::GetCommonData();
     char path[] = "/0.bin";
 
@@ -912,9 +909,6 @@ namespace rnd {
 
   extern "C" void SaveFile_RemoveStoredTradeItem(u16 item, u8 slot) {
     // This is a get item ID, we need to translate it to the regular item ID.
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: Item and slot are %#04x %u\n", __func__, item, slot);
-#endif
     if (slot != 5 && slot != 17)
       return;
     ItemRow* gidItemRow = ItemTable_GetItemRowFromIndex(item);
@@ -923,10 +917,6 @@ namespace rnd {
     for (int i = 0; i < 9; i++) {
       if (gidItemRow->itemId != (u8)gExtSaveData.collectedTradeItems[i] && firstItem == game::ItemId::None) {
         if (slot == 17 && i > 5 && i < 8) {
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-          rnd::util::Print("%s: Slot is 17 and our found item is %#04x\n", __func__,
-                           gExtSaveData.collectedTradeItems[i]);
-#endif
           firstItem = gExtSaveData.collectedTradeItems[i];
         }
 
@@ -942,9 +932,8 @@ namespace rnd {
     saveData.inventory.items[slot] = firstItem;
   }
   extern "C" void SaveFile_RemoveTradeItemFromSlot(u16 item, u8 slot) {
-    // This is a get item ID, we need to translate it to the regular item ID.
     if (slot == 5) {
-      for (int i = 0; i < 4; i++) {
+      for (int i = 0; i < 5; i++) {
         if (item == (u16)gExtSaveData.collectedTradeItems[i]) {
           gExtSaveData.collectedTradeItems[i] = game::ItemId::None;
           break;

--- a/code/source/rnd/settings.cpp
+++ b/code/source/rnd/settings.cpp
@@ -213,7 +213,7 @@ namespace rnd {
       "Bunny Hood",
       "Keaton Mask",
       "Garo Mask",
-      "ROmani Mask",
+      "Romani Mask",
       "Circus Leader's Mask",
       "Postman Hat",
       "Couple's Mask",


### PR DESCRIPTION
- Fix Ocean Deed crashing game by moving instructions down a few bytes past an `stmdb` call.
- Fix item override for progressive items and deed items.
- Fix Romani Mask hash string to remove the capital O.