### PR TITLE
Fix: Remove internal save check for mystery milk quest on cycle reset.

### DIFF
--- a/code/mm.ld
+++ b/code/mm.ld
@@ -111,6 +111,10 @@ SECTIONS{
     *(.patch_DoNotRemoveKeys)
   }
 
+  .patch_RemoveMysteryMilkFlagCheck 0x1C987C : {
+    *(.patch_RemoveMysteryMilkFlagCheck)
+  }
+
   .patch_DoNotGiveSwordBackOnReset 0x1C98DC : {
     *(.patch_DoNotGiveSwordBackOnReset)
   }

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -171,6 +171,12 @@ patch_BlastMaskCooldown:
 patch_RemoveRemainsStateCheck:
     b hook_RemainsCheckValue
 
+@ Remove the check for anonymous_153 in the save statements and ALWAYS remove mystery/spoiled milk from inventory.
+.section .patch_RemoveMysteryMilkFlagCheck
+.global patch_RemoveMysteryMilkFlagCheck
+patch_RemoveMysteryMilkFlagCheck:
+    b 0x1C997C
+
 .section .patch_OverrideBomberTextID
 .global OverrideBomberTextID_patch
 OverrideBomberTextID_patch:


### PR DESCRIPTION
We wish to always remove mystery milk since we never give refills.