### PR TITLE
Fix Remains Shuffling Giving Base Item

### DIFF
--- a/code/include/game/items.h
+++ b/code/include/game/items.h
@@ -277,6 +277,7 @@ namespace game {
 
   // Mask IDs are action IDs - 0x3b
   enum class MaskId : u8 {
+    None = 0x00,
     MaskOfTruth = 0x01,
     BunnyHood = 0x04,
     BlastMask = 0x12,

--- a/code/include/rnd/link.h
+++ b/code/include/rnd/link.h
@@ -17,6 +17,7 @@ namespace rnd::link {
   void FixFreeCameraReset();
   extern "C" void AssignSwordForHoneyDarling();
   extern "C" void RemoveSwordFromHoneyDarling();
+  extern "C" void ResetPlayerForm();
 
 }  // namespace rnd::link
 

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -292,6 +292,10 @@ SECTIONS{
     *(.patch_CheckDungeonSmallKeys)
   }
 
+  .patch_OverrideRemainGetItem 0x2347F8 : {
+    *(.patch_OverrideRemainGetItem)
+  }
+
 	.patch_DisableMilkTimer 0x234BFC : {
 		*(.patch_DisableMilkTimer)
 	}
@@ -320,13 +324,14 @@ SECTIONS{
     *(.patch_OverrideItemID)
   }
 
+  .patch_TwinmoldConsistentDamage 0x28E544 : {
+    *(.patch_TwinmoldConsistentDamage)
+  }
+
   .patch_EnteringLocation 0x23AA54 : {
     *(.patch_EnteringLocation)
   }
 
-  .patch_TwinmoldConsistentDamage 0x28E544 : {
-    *(.patch_TwinmoldConsistentDamage)
-  }
 
   .patch_FasterBlockMovement 0x2AC634 : {
     *(.patch_FasterBlockMovement)

--- a/code/source/asm/item_override_hooks.s
+++ b/code/source/asm/item_override_hooks.s
@@ -53,6 +53,22 @@ noOverrideItemIdIndex:
     ldrsh r0, [r0, #-6]
     bx lr
 
+.global hook_OverrideRemainGetItem
+hook_OverrideRemainGetItem:
+    push {r0-r12,lr}
+    bl ResetPlayerForm
+    pop {r0-r12,lr}
+    push {r2}
+    ldr r2,.rActiveItemRow_addr
+    ldr r2,[r2]
+    cmp r2,#0x0
+    pop {r2}
+    bne 0x23406C
+    cmp r2,#0x3
+    bhi 0x234878
+    bx lr
+    
+
 .global hook_OverrideDrawIndex
 hook_OverrideDrawIndex:
     ldr r0,.rActiveItemGraphicId_addr

--- a/code/source/asm/item_override_patches.s
+++ b/code/source/asm/item_override_patches.s
@@ -17,6 +17,11 @@ patch_OverrideItemIdIndex:
 @TODO: Branch off to hook and load addr that is needed from text ID.
     bl hook_OverrideItemIdIndex
 
+.section .patch_OverrideRemainGetItem
+.global patch_OverrideRemainGetItem
+patch_OverrideRemainGetItem:
+    bl hook_OverrideRemainGetItem
+
 .section .patch_ChangeDrawItemIndex
 .global OverrideDrawIndex_patch
 OverrideDrawIndex_patch:

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -106,8 +106,6 @@ namespace rnd {
     const u32 pressedButtons = gctx->pad_state.input.buttons.flags;
 // const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    // game::SaveData& saveData = game::GetCommonData().save;
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
     if (pressedButtons == (u32)game::pad::Button::ZR) {
       yPos += 10.00f;
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
@@ -121,7 +119,6 @@ namespace rnd {
     } else if (pressedButtons == (u32)game::pad::Button::Down) {
       zPos -= 10.00f;
     }
-#endif
 #endif
     if (gSettingsContext.customMaskButton != 0 && pressedButtons == gSettingsContext.customMaskButton) {
       game::ui::OpenScreen(game::ui::ScreenType::Masks);

--- a/code/source/rnd/link.cpp
+++ b/code/source/rnd/link.cpp
@@ -383,6 +383,14 @@ namespace rnd::link {
       hadSword = true;
     }
   }
+
+  void ResetPlayerForm() {
+    game::GlobalContext* gctx = GetContext().gctx;
+    game::SaveData& saveData = game::GetCommonData().save;
+    saveData.mask = game::MaskId::None;
+    saveData.player_form = game::act::Player::Form::Human;
+    // 0x3E0ADC
+  }
   }
 
 }  // namespace rnd::link


### PR DESCRIPTION
This patch will now ensure we do not give the user a remains on fight completion.

This also fixes the issue where masks wouldn't be removed during the giant's cutscenes. No more dangerous FD after fights, he was a menace.