### PR TITLE
Remove temple clearing check from Koume's messaging scripts.

### DIFF
--- a/code/mm.ld
+++ b/code/mm.ld
@@ -586,6 +586,10 @@ SECTIONS{
     *(.patch_HandleOcarinaHooks)
   }
 
+  .patch_RemoveWoodfallClearConditionFromBoatHouse 0x6737E8 : {
+      *(.patch_RemoveWoodfallClearConditionFromBoatHouse)
+  }
+
   . = 0x61CD8C;
 	/* Addr already 4 byte aligned! */
 	/* . = ALIGN(4); */

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -282,6 +282,21 @@ patch_CheckMasksOnMoon:
 RemoveJimWhenExitingHideout_patch:
     cmp r0,r0
 
+@ This patch performs the same event check to see if Koume was saved,
+@ overriding the check to see if woodfall was cleared. This is due
+@ to the fact you could beat the temple out of logic from saving koume
+@ so this removes the temple check, and checks to see if she was saved twice.
+@ For more information on the message system, see the following links in MM decomp
+@ https://github.com/zeldaret/mm/blob/6541532abb5c03088ad67748bbb23965c654127e/src/overlays/actors/ovl_En_Dnh/z_en_dnh.c#L21
+@ https://github.com/zeldaret/mm/blob/main/include/z64msgevent.h#L354
+.section .patch_RemoveWoodfallClearConditionFromBoatHouse
+.global patch_RemoveWoodfallClearConditionFromBoatHouse
+patch_RemoveWoodfallClearConditionFromBoatHouse:
+    .byte 0x0C
+    .byte 0x08
+    .byte 0x00
+    .byte 0x08
+
 .section .patch_loader
 .global loader_patch
 loader_patch:

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -45,8 +45,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x56;
     rItemOverrides[1].key.scene = 0x6F;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0x54;
-    rItemOverrides[1].value.looksLikeItemId = 0x54;
+    rItemOverrides[1].value.getItemId = 0x59;
+    rItemOverrides[1].value.looksLikeItemId = 0x59;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;


### PR DESCRIPTION
This should fix the bug that made users have a lockout check for the boat ride if they beat the woodfall temple first, and chose not to save Koume, or broke logic and beat the temple without the boat.