### PR TITLE
Gold Skulltula Overrides

### DIFF
--- a/code/include/rnd/actors/en_si.h
+++ b/code/include/rnd/actors/en_si.h
@@ -1,0 +1,21 @@
+#ifndef _RND_ACTORS_EN_SI_H_
+#define _RND_ACTORS_EN_SI_H_
+
+#include "game/actor.h"
+#include "rnd/models.h"
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#include "common/debug.h"
+extern "C" {
+#include <3ds/svc.h>
+}
+#endif
+namespace rnd {
+  extern "C" {
+  void En_Si_Init(game::act::Actor* actor, game::GlobalContext* gctx);
+
+  void En_Si_Draw(game::act::Actor* actor, game::GlobalContext* gctx);
+
+  void En_Si_Destroy(game::act::Actor* self, game::GlobalContext* gctx);
+  }
+}  // namespace rnd
+#endif

--- a/code/include/rnd/item_override.h
+++ b/code/include/rnd/item_override.h
@@ -452,6 +452,7 @@ namespace rnd {
   extern "C" bool ItemOverride_CheckTingleMaps(u16, game::GlobalContext*);
   extern "C" u32 ItemOverride_GetGaboraExtData();
   extern "C" u32 ItemOverride_GetOshExtData();
+  extern "C" u8 ItemOverride_OverrideSkullToken(game::GlobalContext*, game::act::Actor*);
   extern "C" u32 rActiveItemGraphicId;
   extern "C" ItemOverride rItemOverrides[640];
   extern "C" u16 rStoredTextId;

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -280,6 +280,18 @@ SECTIONS{
     *(.patch_SecondZoraSwimCheck)
   }
 
+  .patch_RemoveRemainsStateCheck 0x22B7BC : {
+    *(.patch_RemoveRemainsStateCheck)
+  }
+
+  .patch_ChangeDrawItemIndex 0x22F24C : {
+    *(.patch_ChangeDrawItemIndex)
+  }
+
+  .patch_ChangeDrawItemIndexSecond 0x22F474 : {
+    *(.patch_ChangeDrawItemIndexSecond)
+  }
+
   .patch_ForceSwordUpgradeOnHuman 0x233D88 : {
     *(.patch_ForceSwordUpgradeOnHuman)
   }
@@ -302,18 +314,6 @@ SECTIONS{
 
   .patch_RemoveRSHealthThree 0x235800 : {
     *(.patch_RemoveRazordSwordHealthThree)
-  }
-
-  .patch_RemoveRemainsStateCheck 0x22B7BC : {
-    *(.patch_RemoveRemainsStateCheck)
-  }
-
-  .patch_ChangeDrawItemIndex 0x22F24C : {
-    *(.patch_ChangeDrawItemIndex)
-  }
-
-  .patch_ChangeDrawItemIndexSecond 0x22F474 : {
-    *(.patch_ChangeDrawItemIndexSecond)
   }
 
   .patch_OverrideTextID 0x2310FC : {
@@ -536,6 +536,14 @@ SECTIONS{
 
   .patch_RemoveJimWhenExitingHideout 0x4B6964 : {
     *(.patch_RemoveJimWhenExitingHideout)
+  }
+
+  .patch_SkulltulaOverrideOne 0x529F94 : {
+    *(.patch_SkulltulaOverrideOne)
+  }
+
+  .patch_SkulltulaOverrideTwo 0x52A044 : {
+    *(.patch_SkulltulaOverrideTwo)
   }
 
   .patch_ReadGamePad 0x59BA10 : {

--- a/code/source/asm/item_override_hooks.s
+++ b/code/source/asm/item_override_hooks.s
@@ -261,3 +261,29 @@ hook_ChangeSOHToCustomText:
     bl ItemOverride_SwapSoHGetItemText
     pop {r0-r2, lr}
     b 0x186814
+
+.global hook_SkulltulaOverrideOne
+hook_SkulltulaOverrideOne:
+    push {r0-r12,lr}
+    cpy r1,r5
+    bl ItemOverride_OverrideSkullToken
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    bne skulltulaOverridden
+    bl 0x233BEC
+    b 0x529F98
+skulltulaOverridden:
+    b 0x529FBC
+
+.global hook_SkulltulaOverrideTwo
+hook_SkulltulaOverrideTwo:
+    push {r0-r12,lr}
+    cpy r1,r5
+    bl ItemOverride_OverrideSkullToken
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    bne skulltulaOverriddenTwo
+    bl 0x233BEC
+    b 0x52A048
+skulltulaOverriddenTwo:
+    b 0x52A06C

--- a/code/source/asm/item_override_patches.s
+++ b/code/source/asm/item_override_patches.s
@@ -108,8 +108,17 @@ patch_RemoveCouplesMaskMessage:
 
 @ This should remove the overwriting message for when the
 @ user receives the Zora Mask.
-@ Largely untested, need to check for any UB.
 .section .patch_RemoveSOHCutesceneAfterMessage
 .global patch_RemoveSOHCutesceneAfterMessage
 patch_RemoveSOHCutesceneAfterMessage:
     b hook_ChangeSOHToCustomText
+
+.section .patch_SkulltulaOverrideOne
+.global patch_SkulltulaOverrideOne
+patch_SkulltulaOverrideOne:
+    bl hook_SkulltulaOverrideOne
+
+.section .patch_SkulltulaOverrideTwo
+.global patch_SkulltulaOverrideTwo
+patch_SkulltulaOverrideTwo:
+    bl hook_SkulltulaOverrideTwo

--- a/code/source/rnd/actors/en_si.cpp
+++ b/code/source/rnd/actors/en_si.cpp
@@ -1,0 +1,22 @@
+#include "rnd/actors/en_si.h"
+
+namespace rnd {
+  extern "C" {
+  void En_Si_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
+    util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x2E7FCC)(actor, gctx);
+    Model_SpawnByActor(actor, GetContext().gctx, 0x20);
+  }
+
+  void En_Si_Draw(game::act::Actor* actor, game::GlobalContext* gctx) {
+    if (!Model_DrawByActor(actor)) {
+      util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x367C14)(actor, gctx);
+    }
+  }
+
+  void En_Si_Destroy(game::act::Actor* self, game::GlobalContext* gctx) {
+    Model_DestroyByActor(self);
+    util::GetPointer<void(game::act::Actor*)>(0x51159C)(self);
+  }
+  }
+
+}  // namespace rnd

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -648,12 +648,8 @@ namespace rnd {
 
   void ItemOverride_GetItemTextAndItemID(game::act::Player* actor) {
     if (rActiveItemRow != NULL) {
+      // Check and see if we have trade items or repeatable bottles and add to the array.
       if (rActiveItemOverride.key.type == ItemOverride_Type::OVR_CHEST) {
-// Check and see if we have trade items or repeatable bottles and add to the array.
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        rnd::util::Print("%s: Active item row item ID is %#04x and key flag is %#04x\n", __func__,
-                         rActiveItemRow->itemId, rActiveItemOverride.key.flag);
-#endif
         // Only set if we're not a trade item.
         if ((rActiveItemRow->itemId < 0x28 || rActiveItemRow->itemId > 0x30) && (rActiveItemRow->itemId < 0x9F)) {
           gExtSaveData.chestRewarded[rActiveItemOverride.key.scene][rActiveItemOverride.key.flag] = 1;
@@ -664,8 +660,10 @@ namespace rnd {
       u8 itemId = rActiveItemRow->itemId;
       ItemTable_CallEffect(rActiveItemRow);
       // Only check if we have the ID set, that means text is displayed elsewhere.
-      if (rStoredTextId == 0)
+      if (rStoredTextId == 0) {
         gctx->ShowMessage(textId, actor);
+      }
+        
       // Get_Item_Handler. Don't give ice traps, since it may cause UB.
       if (itemId != (u8)game::ItemId::None) {
         util::GetPointer<int(game::GlobalContext*, game::ItemId)>(0x233BEC)(gctx, (game::ItemId)itemId);
@@ -1045,6 +1043,16 @@ namespace rnd {
 
   u32 ItemOverride_GetOshExtData() {
     return (u32)gExtSaveData.givenItemChecks.enOshGivenItem;
+  }
+
+  u8 ItemOverride_OverrideSkullToken(game::GlobalContext* gctx, game::act::Actor* actor) {
+    s16 getItemId = gctx->scene == game::SceneId::SwampSpiderHouse ? 0x52 : 0x6D;
+    ItemOverride_GetItem(gctx, actor, gctx->GetPlayerActor(), getItemId);
+    if (rActiveItemRow != NULL) {
+      ItemOverride_GetItemTextAndItemID(gctx->GetPlayerActor());
+      return true;
+    }
+    return false;
   }
   }
 }  // namespace rnd

--- a/code/source/rnd/link.cpp
+++ b/code/source/rnd/link.cpp
@@ -385,11 +385,9 @@ namespace rnd::link {
   }
 
   void ResetPlayerForm() {
-    game::GlobalContext* gctx = GetContext().gctx;
     game::SaveData& saveData = game::GetCommonData().save;
     saveData.mask = game::MaskId::None;
     saveData.player_form = game::act::Player::Form::Human;
-    // 0x3E0ADC
   }
   }
 

--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -1,6 +1,7 @@
 #include "rnd/models.h"
 #include "rnd/actors/dm_hina.h"
 #include "rnd/actors/dmchar05.h"
+#include "rnd/actors/en_si.h"
 #include "rnd/actors/item00.h"
 #include "rnd/actors/item_b_heart.h"
 #define LOADEDMODELS_MAX 16
@@ -275,9 +276,14 @@ namespace rnd {
     // overlayTable[0xDC].info->draw_fn = Dm_Hina_Draw;
     // overlayTable[0xDC].info->deinit_fn = Dm_Hina_Destroy;
 
-    overlayTable[0x2F].info->deinit_fn = ItemBHeart_Destroy;
-    overlayTable[0x2F].info->draw_fn = ItemBHeart_Draw;
     overlayTable[0x2F].info->init_fn = ItemBHeart_Init;
+    overlayTable[0x2F].info->draw_fn = ItemBHeart_Draw;
+    overlayTable[0x2F].info->deinit_fn = ItemBHeart_Destroy;
+    
+    overlayTable[0x99].info->init_fn = En_Si_Init;
+    overlayTable[0x99].info->draw_fn = En_Si_Draw;
+    overlayTable[0x99].info->deinit_fn = En_Si_Destroy;
+    
 
     // overlayTable[0x12D].info->init_fn = DMChar05_Init;
     // overlayTable[0x12D].info->draw_fn = DMChar05_Draw;

--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -279,11 +279,10 @@ namespace rnd {
     overlayTable[0x2F].info->init_fn = ItemBHeart_Init;
     overlayTable[0x2F].info->draw_fn = ItemBHeart_Draw;
     overlayTable[0x2F].info->deinit_fn = ItemBHeart_Destroy;
-    
+
     overlayTable[0x99].info->init_fn = En_Si_Init;
     overlayTable[0x99].info->draw_fn = En_Si_Draw;
     overlayTable[0x99].info->deinit_fn = En_Si_Destroy;
-    
 
     // overlayTable[0x12D].info->init_fn = DMChar05_Init;
     // overlayTable[0x12D].info->draw_fn = DMChar05_Draw;


### PR DESCRIPTION
This change should now allow gold skulltula tokens to be overridden. If no override exists, then it falls through the basic functionality. Movement with text boxes is still included with collecting skulltulas.