### PR TITLE
Song Of Healing Model Overrides

### DIFF
--- a/code/include/game/actor.h
+++ b/code/include/game/actor.h
@@ -347,45 +347,17 @@ namespace game::act {
   };
   static_assert(sizeof(DayTimerActor) == 0x20C);
 
-  typedef void (*SkeletonAnimationModelFunc)(struct SkeletonAnimationModel*);
-  struct SkeletonAnimationModel_VTable {
-    // u8 gap_00[4];
-    SkeletonAnimationModelFunc destroy_function;
-    u8 gap_4[4];
+  struct sa_unk_d4 {
+    void* field_00;
+    void* field_04;
+    float field_08;
+    int field_0c;
+    float field_10;
+    float field_14;
+    z3d_nn_math_MTX34 * mtx;
+    u8 gap_1C[184];
   };
-
-  struct SkeletonAnimationModel_unk_10 {
-    void* unk_00;
-    void* unk_04;
-    s32 unk_08;
-    s32 unk_0C;
-    s32 unk_10;
-  };
-  static_assert(sizeof(SkeletonAnimationModel_unk_10) == 0x14);
-
-  struct SkeletonAnimationModel_unk_0C {
-    SkeletonAnimationModel_unk_10* unk_00;
-    void* cmabManager;
-    f32 curFrame;
-    f32 animSpeed;
-    s8 animMode;
-    u8 unk_11[0x87];
-  };
-  static_assert(sizeof(SkeletonAnimationModel_unk_0C) == 0x98);
-
-  struct SkeletonAnimationModel {
-    SkeletonAnimationModel_VTable* vtbl;
-    u8 unk_04[8];
-    SkeletonAnimationModel_unk_0C* unk_0C;
-    SkeletonAnimationModel_unk_10* unk_10;
-    void* unk_draw_struct_14;
-    u8 gap_18[100];
-    float mtx[3][4];
-    s8 field_AC;
-    u8 gap_AD[3];
-  };
-  static_assert(offsetof(SkeletonAnimationModel, field_AC) == 0xAC);
-  static_assert(sizeof(SkeletonAnimationModel) == 0xB0);
+  static_assert(sizeof(sa_unk_d4) == 0xD4);
 
   ActorOverlayInfo* GetActorOverlayInfoTable();
 

--- a/code/include/game/as.h
+++ b/code/include/game/as.h
@@ -52,7 +52,7 @@ namespace game::as {
     int field_28;
     int field_2C;
     int field_30;
-    int field_34;
+    void * field_34;
     int field_38;
     State state;
     u8 gap_64[24];

--- a/code/include/rnd/actors/dm_char03.h
+++ b/code/include/rnd/actors/dm_char03.h
@@ -21,7 +21,7 @@ namespace rnd {
     void* skelAnimeModel;
   };
   static_assert(sizeof(Dm_Char03) == 0x29C);
-
+  extern "C" float rDmChar03Scale;
   void Dm_Char03_Init(game::act::Actor* actor, game::GlobalContext* gctx);
   void Dm_Char03_Draw(game::act::Actor* actor, game::GlobalContext* gctx);
 

--- a/code/include/rnd/actors/dm_char03.h
+++ b/code/include/rnd/actors/dm_char03.h
@@ -1,0 +1,29 @@
+#ifndef _RND_ACTORS_DM_CHAR03_H_
+#define _RND_ACTORS_DM_CHAR03_H_
+
+#include "game/actor.h"
+#include "rnd/models.h"
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#include "common/debug.h"
+extern "C" {
+#include <3ds/svc.h>
+}
+#endif
+namespace rnd {
+  struct Dm_Char03 : public game::act::Actor {
+    game::as::ActorUtil* actor_util;
+    u8 gap_1fc[136];
+    void* field_284;
+    u16 field_288;
+    u8 field_28a;
+    u8 object_id;
+    z3dVec3f some_pos;
+    void* skelAnimeModel;
+  };
+  static_assert(sizeof(Dm_Char03) == 0x29C);
+
+  void Dm_Char03_Init(game::act::Actor* actor, game::GlobalContext* gctx);
+  void Dm_Char03_Draw(game::act::Actor* actor, game::GlobalContext* gctx);
+
+}  // namespace rnd
+#endif

--- a/code/include/rnd/actors/dm_char05.h
+++ b/code/include/rnd/actors/dm_char05.h
@@ -22,17 +22,10 @@ namespace rnd {
   };
   static_assert(sizeof(Dm_Char05) == 0x2B8);
 
-  extern "C" {
-  void SpawnDmChar05Model(game::act::Actor*);
-  u8 DrawDmChar05Model(game::act::Actor*);
-  void DmChar05_rDestroy(game::act::Actor*, game::GlobalContext*);
-  void DMChar05_Init(game::act::Actor* actor, game::GlobalContext* gctx);
-
   void DMChar05_Init(game::act::Actor* actor, game::GlobalContext* gctx);
 
   void DMChar05_Draw(game::act::Actor* actor, game::GlobalContext* gctx);
 
   void DMChar05_Destroy(game::act::Actor* self, game::GlobalContext* gctx);
-  }
 }  // namespace rnd
 #endif

--- a/code/include/rnd/actors/dm_char05.h
+++ b/code/include/rnd/actors/dm_char05.h
@@ -1,5 +1,5 @@
-#ifndef _RND_ACTORS_DMCHAR05_H_
-#define _RND_ACTORS_DMCHAR05_H_
+#ifndef _RND_ACTORS_DM_CHAR05_H_
+#define _RND_ACTORS_DM_CHAR05_H_
 
 #include "game/actor.h"
 #include "rnd/models.h"

--- a/code/include/rnd/actors/dmchar05.h
+++ b/code/include/rnd/actors/dmchar05.h
@@ -10,6 +10,19 @@ extern "C" {
 }
 #endif
 namespace rnd {
+  struct Dm_Char05 : public game::act::Actor {
+    game::as::ActorUtil* actor_util;
+    u8 gap_1fc[136];
+    void * skelAnimeModel;
+    void* calc_fn;
+    u16 field_28c;
+    u8 field_28e;
+    u8 object_idx;
+    float field_290[4];
+    u8 gap_2a0[24];
+  };
+  static_assert(sizeof(Dm_Char05) == 0x2B8);
+
   extern "C" {
   void SpawnDmChar05Model(game::act::Actor*);
   u8 DrawDmChar05Model(game::act::Actor*);

--- a/code/include/rnd/actors/dmchar05.h
+++ b/code/include/rnd/actors/dmchar05.h
@@ -11,8 +11,7 @@ extern "C" {
 #endif
 namespace rnd {
   struct Dm_Char05 : public game::act::Actor {
-    game::as::ActorUtil* actor_util;
-    u8 gap_1fc[136];
+    game::as::ActorUtil actor_util;
     void * skelAnimeModel;
     void* calc_fn;
     u16 field_28c;

--- a/code/include/rnd/models.h
+++ b/code/include/rnd/models.h
@@ -45,7 +45,7 @@ namespace rnd {
   void Model_DestroyByActor(game::act::Actor* actor);
   void Model_DestroyAll(void);
   s32 Model_DrawByActor(game::act::Actor* actor);
-  void* Model_GetOverrideSaModel(game::act::Actor* actor);
+  Model* Model_GetOverrideSaModel(game::act::Actor* actor);
   void Actor_Init();
 }  // namespace rnd
 #endif  //_RND_MODELS_H_

--- a/code/include/rnd/models.h
+++ b/code/include/rnd/models.h
@@ -45,6 +45,7 @@ namespace rnd {
   void Model_DestroyByActor(game::act::Actor* actor);
   void Model_DestroyAll(void);
   s32 Model_DrawByActor(game::act::Actor* actor);
+  void* Model_GetOverrideSaModel(game::act::Actor* actor);
   void Actor_Init();
 }  // namespace rnd
 #endif  //_RND_MODELS_H_

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -421,9 +421,9 @@ SECTIONS{
     *(.patch_CheckMoTRequirement)
   }
 
-  .patch_DmChar05GoronInit 0x3C6D70 : {
+  /* .patch_DmChar05GoronInit 0x3C6D70 : {
     *(.patch_DmChar05GoronInit)
-  }
+  } */
 
   .patch_OverrideItem00Init 0x3D018C : {
     *(.patch_OverrideItem00Init)
@@ -501,9 +501,9 @@ SECTIONS{
     *(.patch_RemoveSoHMaskAppearing)
   } */
 
-   .patch_DmChar05GoronDraw 0x41D31C : {
+  /* .patch_DmChar05GoronDraw 0x41D31C : {
     *(.patch_DmChar05GoronDraw)
-  }
+  } */
 
   /* .patch_tmp 0x41d224 : {
     *(.patch_tmp)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -296,6 +296,10 @@ SECTIONS{
     *(.patch_ChangeDrawItemIndexSecond)
   }
 
+  .patch_RemoveSkulltulaTokenGetItem 0x233C60 : {
+    *(.patch_RemoveSkulltulaTokenGetItem)
+  }
+
   .patch_ForceSwordUpgradeOnHuman 0x233D88 : {
     *(.patch_ForceSwordUpgradeOnHuman)
   }
@@ -451,10 +455,6 @@ SECTIONS{
 
   .patch_TradeItemDeleteMoonsTear 0x3B5214 : {
     *(.patch_TradeItemDeleteMoonsTear)
-  }
-
-  .patch_DmChar03ReplaceOverheadSaModel 0x3B9248 : {
-    *(.patch_DmChar03ReplaceOverheadSaModel)
   }
 
   .patch_OverrideWalletSpiderHouseTwo 0x3BF078 : {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -413,6 +413,9 @@ SECTIONS{
     *(.patch_CheckMoTRequirement)
   }
 
+  .patch_DmChar05GoronInit 0x3C6D70 : {
+    *(.patch_DmChar05GoronInit)
+  }
 
   .patch_OverrideItem00Init 0x3D018C : {
     *(.patch_OverrideItem00Init)
@@ -490,6 +493,14 @@ SECTIONS{
     *(.patch_RemoveSoHMaskAppearing)
   } */
 
+   .patch_DmChar05GoronDraw 0x41D31C : {
+    *(.patch_DmChar05GoronDraw)
+  }
+
+  /* .patch_tmp 0x41d224 : {
+    *(.patch_tmp)
+  } */
+
   .patch_GibdoMaskGiveItem 0x41DC48 : {
     *(.patch_GibdoMaskGiveItem)
   }
@@ -537,6 +548,15 @@ SECTIONS{
   .patch_RemoveJimWhenExitingHideout 0x4B6964 : {
     *(.patch_RemoveJimWhenExitingHideout)
   }
+
+  .patch_DmChar05GetObjectStatus 0x50F3DC : {
+    *(.patch_DmChar05GetObjectStatus)
+  }
+
+  /* XXX: May need this in the future, but will have to steal object ID from table in function call. */
+  /* .patch_DmChar05GetObjectStatusTwo 0x504CA8 : {
+    *(.patch_DmChar05GetObjectStatusTwo)
+  } */
 
   .patch_SkulltulaOverrideOne 0x529F94 : {
     *(.patch_SkulltulaOverrideOne)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -280,6 +280,10 @@ SECTIONS{
     *(.patch_SecondZoraSwimCheck)
   }
 
+  .patch_GetExtendedObjectStatus 0x222330 : {
+    *(.patch_GetExtendedObjectStatus)
+  }
+
   .patch_RemoveRemainsStateCheck 0x22B7BC : {
     *(.patch_RemoveRemainsStateCheck)
   }
@@ -448,6 +452,10 @@ SECTIONS{
   .patch_TradeItemDeleteMoonsTear 0x3B5214 : {
     *(.patch_TradeItemDeleteMoonsTear)
   }
+
+  /* .patch_DmChar03ReplaceOverheadSaModel 0x3B9250 : {
+    *(.patch_DmChar03ReplaceOverheadSaModel)
+  } */
 
   .patch_OverrideWalletSpiderHouseTwo 0x3BF078 : {
     *(.patch_OverrideWalletSpiderHouseTwo)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -453,9 +453,9 @@ SECTIONS{
     *(.patch_TradeItemDeleteMoonsTear)
   }
 
-  /* .patch_DmChar03ReplaceOverheadSaModel 0x3B9250 : {
+  .patch_DmChar03ReplaceOverheadSaModel 0x3B9248 : {
     *(.patch_DmChar03ReplaceOverheadSaModel)
-  } */
+  }
 
   .patch_OverrideWalletSpiderHouseTwo 0x3BF078 : {
     *(.patch_OverrideWalletSpiderHouseTwo)

--- a/code/source/asm/item_override_hooks.s
+++ b/code/source/asm/item_override_hooks.s
@@ -91,6 +91,20 @@ noOverrideGraphicIdSecond:
     ldrsh r0, [r8,#2]
     b 0x22F478
 
+.global hook_RemoveSkulltulaTokenGetItem
+hook_RemoveSkulltulaTokenGetItem:
+    push {r0-r12,lr}
+    ldr r0,.rActiveItemRow_addr
+    ldr r0,[r0]
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    beq skulltulaNotOverridden
+    bx lr
+skulltulaNotOverridden:
+    cmp r4, #0x6E
+    beq 0x233CB8
+    bx lr
+
 .global hook_OverrideTextID
 hook_OverrideTextID:
     push {r3}

--- a/code/source/asm/item_override_patches.s
+++ b/code/source/asm/item_override_patches.s
@@ -32,6 +32,11 @@ OverrideDrawIndex_patch:
 patch_ChangeDrawItemIndexSecond:
     b hook_OverrideDrawIndexSecond
 
+.section .patch_RemoveSkulltulaTokenGetItem
+.global patch_RemoveSkulltulaTokenGetItem
+patch_RemoveSkulltulaTokenGetItem:
+    bl hook_RemoveSkulltulaTokenGetItem
+
 .section .patch_OverrideTextID
 .global OverrideTextID_patch
 OverrideTextID_patch:

--- a/code/source/asm/model_hooks.s
+++ b/code/source/asm/model_hooks.s
@@ -9,13 +9,13 @@ hook_ModelSpawnGetObjectStatus:
     pop {r1-r12, lr}
     bx lr
 
-.global hook_DmChar05GoronInit
-hook_DmChar05GoronInit:
-    push {r0-r12,lr}
-    bl DmChar05_Goron_Init
-    pop {r0-r12, lr}
-    add r0,r4,#0xC0
-    bx lr
+@ .global hook_DmChar05GoronInit
+@ hook_DmChar05GoronInit:
+@     push {r0-r12,lr}
+@     bl DmChar05_Goron_Init
+@     pop {r0-r12, lr}
+@     add r0,r4,#0xC0
+@     bx lr
 
 .global hook_OverrideItem00Init
 hook_OverrideItem00Init:
@@ -25,19 +25,19 @@ hook_OverrideItem00Init:
     pop {r0-r12, lr}
     bx lr
 
-.global hook_DmChar05Draw
-hook_DmChar05Draw:
-    push {r0-r12,lr}
-    cpy r0,r4
-    cpy r1,r5
-    bl DmChar05_Draw
-    cmp r0,#0x0
-    pop {r0-r12, lr}
-    beq drawOriginalModel
-    bx lr
-drawOriginalModel:
-    str r0,[r4, #0x284]
-    bx lr
+@ .global hook_DmChar05Draw
+@ hook_DmChar05Draw:
+@     push {r0-r12,lr}
+@     cpy r0,r4
+@     cpy r1,r5
+@     bl DmChar05_Draw
+@     cmp r0,#0x0
+@     pop {r0-r12, lr}
+@     beq drawOriginalModel
+@     bx lr
+@ drawOriginalModel:
+@     str r0,[r4, #0x284]
+@     bx lr
 
 .global hook_OverrideItem00Draw
 hook_OverrideItem00Draw:

--- a/code/source/asm/model_hooks.s
+++ b/code/source/asm/model_hooks.s
@@ -44,11 +44,7 @@ hook_DmChar03ReplaceOverheadSaModel:
     cpy r0,r4
     cpy r1,r5
     bl Dm_Char03_Draw_Asm
-    cmp r0,#0x0
     pop {r0-r12,lr}
-    beq drawOrigDmChar03Model
-    bx lr
-drawOrigDmChar03Model:
     ldr r0,[r4, #0x298]
     bx lr
 

--- a/code/source/asm/model_hooks.s
+++ b/code/source/asm/model_hooks.s
@@ -38,14 +38,18 @@ drawOriginalModel:
     str r0,[r4, #0x284]
     bx lr
     
-.global hook_tmp
-hook_tmp:
+.global hook_DmChar03ReplaceOverheadSaModel
+hook_DmChar03ReplaceOverheadSaModel:
     push {r0-r12,lr}
     cpy r0,r4
     cpy r1,r5
-    bl DmChar05_Draw
-    pop {r0-r12, lr}
-    cmp r0,#0x1
+    bl Dm_Char03_Draw_Asm
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    beq drawOrigDmChar03Model
+    bx lr
+drawOrigDmChar03Model:
+    ldr r0,[r4, #0x298]
     bx lr
 
 .global hook_OverrideItem00Draw

--- a/code/source/asm/model_hooks.s
+++ b/code/source/asm/model_hooks.s
@@ -1,6 +1,7 @@
 .arm
 .text
 
+
 .global hook_ModelSpawnGetObjectStatus
 hook_ModelSpawnGetObjectStatus:
     push {r1-r12, lr}
@@ -36,16 +37,6 @@ hook_DmChar05Draw:
     bx lr
 drawOriginalModel:
     str r0,[r4, #0x284]
-    bx lr
-    
-.global hook_DmChar03ReplaceOverheadSaModel
-hook_DmChar03ReplaceOverheadSaModel:
-    push {r0-r12,lr}
-    cpy r0,r4
-    cpy r1,r5
-    bl Dm_Char03_Draw_Asm
-    pop {r0-r12,lr}
-    ldr r0,[r4, #0x298]
     bx lr
 
 .global hook_OverrideItem00Draw

--- a/code/source/asm/model_hooks.s
+++ b/code/source/asm/model_hooks.s
@@ -8,12 +8,44 @@ hook_ModelSpawnGetObjectStatus:
     pop {r1-r12, lr}
     bx lr
 
+.global hook_DmChar05GoronInit
+hook_DmChar05GoronInit:
+    push {r0-r12,lr}
+    bl DmChar05_Goron_Init
+    pop {r0-r12, lr}
+    add r0,r4,#0xC0
+    bx lr
+
 .global hook_OverrideItem00Init
 hook_OverrideItem00Init:
     cpy r4,r0
     push {r0-r12,lr}
     bl SpawnItem00Model
     pop {r0-r12, lr}
+    bx lr
+
+.global hook_DmChar05Draw
+hook_DmChar05Draw:
+    push {r0-r12,lr}
+    cpy r0,r4
+    cpy r1,r5
+    bl DmChar05_Draw
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    beq drawOriginalModel
+    bx lr
+drawOriginalModel:
+    str r0,[r4, #0x284]
+    bx lr
+    
+.global hook_tmp
+hook_tmp:
+    push {r0-r12,lr}
+    cpy r0,r4
+    cpy r1,r5
+    bl DmChar05_Draw
+    pop {r0-r12, lr}
+    cmp r0,#0x1
     bx lr
 
 .global hook_OverrideItem00Draw

--- a/code/source/asm/model_patches.s
+++ b/code/source/asm/model_patches.s
@@ -15,20 +15,20 @@ patch_ModelSpawnGetObjectStatus:
 patch_GetExtendedObjectStatus:
   bl hook_ModelSpawnGetObjectStatus
 
-.section .patch_DmChar05GoronInit
-.global patch_DmChar05GoronInit
-patch_DmChar05GoronInit:
-  bl hook_DmChar05GoronInit
+@ .section .patch_DmChar05GoronInit
+@ .global patch_DmChar05GoronInit
+@ patch_DmChar05GoronInit:
+@   bl hook_DmChar05GoronInit
 
 .section .patch_OverrideItem00Init
 .global patch_OverrideItem00Init
 patch_OverrideItem00Init:
   bl hook_OverrideItem00Init
 
-.section .patch_DmChar05GoronDraw
-.global patch_DmChar05GoronDraw
-patch_DmChar05GoronDraw:
-  bl hook_DmChar05Draw
+@ .section .patch_DmChar05GoronDraw
+@ .global patch_DmChar05GoronDraw
+@ patch_DmChar05GoronDraw:
+@   bl hook_DmChar05Draw
 
 .section .patch_OverrideItem00Draw
 .global patch_OverrideItem00Draw

--- a/code/source/asm/model_patches.s
+++ b/code/source/asm/model_patches.s
@@ -25,11 +25,6 @@ patch_DmChar05GoronInit:
 patch_OverrideItem00Init:
   bl hook_OverrideItem00Init
 
-.section .patch_DmChar03ReplaceOverheadSaModel
-.global patch_DmChar03ReplaceOverheadSaModel
-patch_DmChar03ReplaceOverheadSaModel:
-  bl hook_DmChar03ReplaceOverheadSaModel
-
 .section .patch_DmChar05GoronDraw
 .global patch_DmChar05GoronDraw
 patch_DmChar05GoronDraw:

--- a/code/source/asm/model_patches.s
+++ b/code/source/asm/model_patches.s
@@ -10,9 +10,9 @@ patch_ExtendedObjectClear:
 patch_ModelSpawnGetObjectStatus:
   bl hook_ModelSpawnGetObjectStatus
 
-.section .patch_ModelSpawnGetObjectStatusTwo
-.global patch_ModelSpawnGetObjectStatusTwo
-patch_ModelSpawnGetObjectStatusTwo:
+.section .patch_GetExtendedObjectStatus
+.global patch_GetExtendedObjectStatus
+patch_GetExtendedObjectStatus:
   bl hook_ModelSpawnGetObjectStatus
 
 .section .patch_DmChar05GoronInit
@@ -25,11 +25,10 @@ patch_DmChar05GoronInit:
 patch_OverrideItem00Init:
   bl hook_OverrideItem00Init
 
-.section .patch_tmp
-.global patch_tmp
-patch_tmp:
-  bl hook_tmp
-@mov r2,#0x45
+.section .patch_DmChar03ReplaceOverheadSaModel
+.global patch_DmChar03ReplaceOverheadSaModel
+patch_DmChar03ReplaceOverheadSaModel:
+  bl hook_DmChar03ReplaceOverheadSaModel
 
 .section .patch_DmChar05GoronDraw
 .global patch_DmChar05GoronDraw

--- a/code/source/asm/model_patches.s
+++ b/code/source/asm/model_patches.s
@@ -10,12 +10,38 @@ patch_ExtendedObjectClear:
 patch_ModelSpawnGetObjectStatus:
   bl hook_ModelSpawnGetObjectStatus
 
+.section .patch_ModelSpawnGetObjectStatusTwo
+.global patch_ModelSpawnGetObjectStatusTwo
+patch_ModelSpawnGetObjectStatusTwo:
+  bl hook_ModelSpawnGetObjectStatus
+
+.section .patch_DmChar05GoronInit
+.global patch_DmChar05GoronInit
+patch_DmChar05GoronInit:
+  bl hook_DmChar05GoronInit
+
 .section .patch_OverrideItem00Init
 .global patch_OverrideItem00Init
 patch_OverrideItem00Init:
   bl hook_OverrideItem00Init
 
+.section .patch_tmp
+.global patch_tmp
+patch_tmp:
+  bl hook_tmp
+@mov r2,#0x45
+
+.section .patch_DmChar05GoronDraw
+.global patch_DmChar05GoronDraw
+patch_DmChar05GoronDraw:
+  bl hook_DmChar05Draw
+
 .section .patch_OverrideItem00Draw
 .global patch_OverrideItem00Draw
 patch_OverrideItem00Draw:
   bl hook_OverrideItem00Draw
+
+.section .patch_DmChar05GetObjectStatus
+.global patch_DmChar05GetObjectStatus
+patch_DmChar05GetObjectStatus:
+  bl hook_ModelSpawnGetObjectStatus

--- a/code/source/rnd/actors/dm_char03.cpp
+++ b/code/source/rnd/actors/dm_char03.cpp
@@ -20,13 +20,12 @@ namespace rnd {
     }
   }
 
-  extern "C" bool Dm_Char03_Draw_Asm(game::act::Actor* actor, game::GlobalContext* gctx) {
+  extern "C" void Dm_Char03_Draw_Asm(game::act::Actor* actor, game::GlobalContext* gctx) {
     void* saModel = Model_GetOverrideSaModel(actor);
-    if (saModel != NULL) {
+    if (saModel != NULL)
       static_cast<Dm_Char03*>(actor)->skelAnimeModel = saModel;
-      return true;
-    } else
-      return false;
+  
+
   }
 
 }  // namespace rnd

--- a/code/source/rnd/actors/dm_char03.cpp
+++ b/code/source/rnd/actors/dm_char03.cpp
@@ -24,16 +24,4 @@ namespace rnd {
     util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x41CE70)(actor, gctx);
   }
 
-  extern "C" void Dm_Char03_Draw_Asm(game::act::Actor* actor, game::GlobalContext* gctx) {
-    Model* model = Model_GetOverrideSaModel(actor);
-    if (model->saModel != NULL) {
-      if (model->objectId == 0x00) {
-        Model_SetScale(actor, model->scale);
-      }
-      static_cast<Dm_Char03*>(actor)->skelAnimeModel = model->saModel;
-      static_cast<Dm_Char03*>(actor)->actor_util->field_34 = model->saModel;
-    }
-    
-    }
-
 }  // namespace rnd

--- a/code/source/rnd/actors/dm_char03.cpp
+++ b/code/source/rnd/actors/dm_char03.cpp
@@ -21,11 +21,14 @@ namespace rnd {
   }
 
   extern "C" void Dm_Char03_Draw_Asm(game::act::Actor* actor, game::GlobalContext* gctx) {
-    void* saModel = Model_GetOverrideSaModel(actor);
-    if (saModel != NULL)
-      static_cast<Dm_Char03*>(actor)->skelAnimeModel = saModel;
-  
-
-  }
+    Model* model = Model_GetOverrideSaModel(actor);
+    if (model->saModel != NULL) {
+      if (model->objectId == 0x00) {
+        Model_SetScale(actor, model->scale);
+      }
+      static_cast<Dm_Char03*>(actor)->skelAnimeModel = model->saModel;
+    }
+    
+    }
 
 }  // namespace rnd

--- a/code/source/rnd/actors/dm_char03.cpp
+++ b/code/source/rnd/actors/dm_char03.cpp
@@ -5,19 +5,23 @@ namespace rnd {
   void Dm_Char03_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
     util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x3C6A38)(actor, gctx);
     Model_SpawnByActor(actor, GetContext().gctx, 0x78);
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: Spawned actor!\n", __func__);
-#endif
+    Model* model = Model_GetOverrideSaModel(actor);
+    
+    // static_cast<Dm_Char03*>(actor)->skelAnimeModel = model->saModel;
+    if (model != NULL) {
+      static_cast<Dm_Char03*>(actor)->actor_util->field_34 = model->saModel;
+      if (model->objectId == 0x01) {
+        auto* scale = util::GetPointer<f32>(0x3B9298);
+        util::Write(scale, 0x00, 0.005f);
+      }
+    }
   }
 
   void Dm_Char03_Draw(game::act::Actor* actor, game::GlobalContext* gctx) {
-    if (static_cast<Dm_Char03*>(actor)->field_28a != 0) {
-      if (!Model_DrawByActor(actor)) {
-        util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x41CE70)(actor, gctx);
-      }
-    } else {
-      util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x41CE70)(actor, gctx);
-    }
+    Model* model = Model_GetOverrideSaModel(actor);
+    static_cast<Dm_Char03*>(actor)->skelAnimeModel = model->saModel;
+    static_cast<Dm_Char03*>(actor)->actor_util->field_34 = model->saModel;
+    util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x41CE70)(actor, gctx);
   }
 
   extern "C" void Dm_Char03_Draw_Asm(game::act::Actor* actor, game::GlobalContext* gctx) {
@@ -27,6 +31,7 @@ namespace rnd {
         Model_SetScale(actor, model->scale);
       }
       static_cast<Dm_Char03*>(actor)->skelAnimeModel = model->saModel;
+      static_cast<Dm_Char03*>(actor)->actor_util->field_34 = model->saModel;
     }
     
     }

--- a/code/source/rnd/actors/dm_char03.cpp
+++ b/code/source/rnd/actors/dm_char03.cpp
@@ -1,0 +1,32 @@
+#include "rnd/actors/dm_char03.h"
+
+namespace rnd {
+
+  void Dm_Char03_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
+    util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x3C6A38)(actor, gctx);
+    Model_SpawnByActor(actor, GetContext().gctx, 0x78);
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Spawned actor!\n", __func__);
+#endif
+  }
+
+  void Dm_Char03_Draw(game::act::Actor* actor, game::GlobalContext* gctx) {
+    if (static_cast<Dm_Char03*>(actor)->field_28a != 0) {
+      if (!Model_DrawByActor(actor)) {
+        util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x41CE70)(actor, gctx);
+      }
+    } else {
+      util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x41CE70)(actor, gctx);
+    }
+  }
+
+  extern "C" bool Dm_Char03_Draw_Asm(game::act::Actor* actor, game::GlobalContext* gctx) {
+    void* saModel = Model_GetOverrideSaModel(actor);
+    if (saModel != NULL) {
+      static_cast<Dm_Char03*>(actor)->skelAnimeModel = saModel;
+      return true;
+    } else
+      return false;
+  }
+
+}  // namespace rnd

--- a/code/source/rnd/actors/dm_char05.cpp
+++ b/code/source/rnd/actors/dm_char05.cpp
@@ -10,9 +10,9 @@ namespace rnd {
   }
 
   u8 DmChar05_Draw(game::act::Actor* actor, game::GlobalContext* gctx) {
-    void* saModel = Model_GetOverrideSaModel(actor);
-    if (saModel != NULL) {
-      static_cast<Dm_Char05*>(actor)->skelAnimeModel = saModel;
+    Model* model = Model_GetOverrideSaModel(actor);
+    if (model->saModel != NULL) {
+      static_cast<Dm_Char05*>(actor)->skelAnimeModel = model->saModel;
       // static_cast<Dm_Char05*>(actor)->actor_util.field_34 = saModel;
       return true;
     } else

--- a/code/source/rnd/actors/dm_char05.cpp
+++ b/code/source/rnd/actors/dm_char05.cpp
@@ -1,4 +1,4 @@
-#include "rnd/actors/dmchar05.h"
+#include "rnd/actors/dm_char05.h"
 
 namespace rnd {
   extern "C" {

--- a/code/source/rnd/actors/dm_char05.cpp
+++ b/code/source/rnd/actors/dm_char05.cpp
@@ -1,6 +1,18 @@
 #include "rnd/actors/dm_char05.h"
 
 namespace rnd {
+  void DmChar05_SetScale(game::act::Actor* actor) {
+    Model* model = Model_GetOverrideSaModel(actor);
+
+    // static_cast<Dm_Char03*>(actor)->skelAnimeModel = model->saModel;
+    if (model != NULL) {
+      static_cast<Dm_Char05*>(actor)->actor_util.field_34 = model->saModel;
+      if (model->objectId == 0x01) {
+        auto* scale = util::GetPointer<f32>(0x41D5B0);
+        util::Write(scale, 0x00, 0.005f);
+      }
+    }
+  }
   extern "C" {
   void DMChar05_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
     util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x3C6CD8)(actor, gctx);
@@ -27,6 +39,7 @@ namespace rnd {
 
   void DmChar05_Goron_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
     Model_SpawnByActor(actor, rnd::GetContext().gctx, 0x79);
+    DmChar05_SetScale(actor);
   }
   
   }

--- a/code/source/rnd/actors/dm_char05.cpp
+++ b/code/source/rnd/actors/dm_char05.cpp
@@ -13,22 +13,29 @@ namespace rnd {
       }
     }
   }
-  extern "C" {
+
   void DMChar05_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
     util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x3C6CD8)(actor, gctx);
-    // TODO: DETERMINE WHICH MASK AND WHATNOT FROM PARAMS.
-    if (actor->params != 0x03)
+    if (actor->params == 0x00) // Goron
       Model_SpawnByActor(actor, GetContext().gctx, 0x79);
+    else if (actor->params == 0x01) // Zora
+      Model_SpawnByActor(actor, GetContext().gctx, 0x7A);
+    else if (actor->params == 0x02)  // Gibdo
+      Model_SpawnByActor(actor, GetContext().gctx, 0x87);
+    else if (actor->params == 0x04)  // Couple's
+      Model_SpawnByActor(actor, GetContext().gctx, 0x85);
+    else if (actor->params == 0x0D)  // Bomber's Notebook
+      Model_SpawnByActor(actor, GetContext().gctx, 0x50);
+    DmChar05_SetScale(actor);
   }
 
-  u8 DmChar05_Draw(game::act::Actor* actor, game::GlobalContext* gctx) {
+  void DMChar05_Draw(game::act::Actor* actor, game::GlobalContext* gctx) {
     Model* model = Model_GetOverrideSaModel(actor);
-    if (model->saModel != NULL) {
+    if (model != NULL) {
       static_cast<Dm_Char05*>(actor)->skelAnimeModel = model->saModel;
-      // static_cast<Dm_Char05*>(actor)->actor_util.field_34 = saModel;
-      return true;
-    } else
-      return false;
+      static_cast<Dm_Char05*>(actor)->actor_util.field_34 = model->saModel;
+    }
+    util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x41D1C8)(actor, gctx);
   }
 
   void DMChar05_Destroy(game::act::Actor* self, game::GlobalContext* gctx) {
@@ -41,7 +48,6 @@ namespace rnd {
     Model_SpawnByActor(actor, rnd::GetContext().gctx, 0x79);
     DmChar05_SetScale(actor);
   }
-  
-  }
+
 
 }  // namespace rnd

--- a/code/source/rnd/actors/dm_hina.cpp
+++ b/code/source/rnd/actors/dm_hina.cpp
@@ -18,4 +18,6 @@ namespace rnd {
     util::GetPointer<void(game::act::Actor*)>(0x34F864)(self);
   }
 
+  
+
 }  // namespace rnd

--- a/code/source/rnd/actors/dmchar05.cpp
+++ b/code/source/rnd/actors/dmchar05.cpp
@@ -13,7 +13,7 @@ namespace rnd {
     void* saModel = Model_GetOverrideSaModel(actor);
     if (saModel != NULL) {
       static_cast<Dm_Char05*>(actor)->skelAnimeModel = saModel;
-      // static_cast<Dm_Char05*>(actor)->actor_util->field_34 = saModel;
+      // static_cast<Dm_Char05*>(actor)->actor_util.field_34 = saModel;
       return true;
     } else
       return false;

--- a/code/source/rnd/actors/dmchar05.cpp
+++ b/code/source/rnd/actors/dmchar05.cpp
@@ -9,14 +9,14 @@ namespace rnd {
       Model_SpawnByActor(actor, GetContext().gctx, 0x79);
   }
 
-  void DMChar05_Draw(game::act::Actor* actor, game::GlobalContext* gctx) {
-    if (actor->params != 0x03) {
-      if (!Model_DrawByActor(actor)) {
-        util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x41D1C8)(actor, gctx);
-      }
-    } else {
-      util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x41D1C8)(actor, gctx);
-    }
+  u8 DmChar05_Draw(game::act::Actor* actor, game::GlobalContext* gctx) {
+    void* saModel = Model_GetOverrideSaModel(actor);
+    if (saModel != NULL) {
+      static_cast<Dm_Char05*>(actor)->skelAnimeModel = saModel;
+      // static_cast<Dm_Char05*>(actor)->actor_util->field_34 = saModel;
+      return true;
+    } else
+      return false;
   }
 
   void DMChar05_Destroy(game::act::Actor* self, game::GlobalContext* gctx) {
@@ -24,6 +24,11 @@ namespace rnd {
       Model_DestroyByActor(self);
     util::GetPointer<void(game::act::Actor*)>(0x3C6F90)(self);
   }
+
+  void DmChar05_Goron_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
+    Model_SpawnByActor(actor, rnd::GetContext().gctx, 0x79);
+  }
+  
   }
 
 }  // namespace rnd

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -13,7 +13,7 @@ namespace rnd {
       gctx->next_entrance = 0x6890;
       cdata.sub13s[0].entrance_index = 0x6890;
       didWarp = true;
-    } else if (gctx->next_entrance == 0x1C05 && gSettingsContext.skipDarmaniCutscene) {
+    } else if (gctx->next_entrance == 0x1C05/* && gSettingsContext.skipDarmaniCutscene*/) {
       gctx->next_entrance = 0x9610;
       cdata.sub13s[0].entrance_index = 0x9610;
       didWarp = true;

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -6,14 +6,11 @@ namespace rnd {
     game::CommonData& cdata = game::GetCommonData();
     game::GlobalContext* gctx = GetContext().gctx;
     bool didWarp = false;
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: Our next entrance is %#08x\n", __func__, gctx->next_entrance);
-#endif
     if (gctx->next_entrance == 0x1C04 && gSettingsContext.skipMikauCutscene) {
       gctx->next_entrance = 0x6890;
       cdata.sub13s[0].entrance_index = 0x6890;
       didWarp = true;
-    } else if (gctx->next_entrance == 0x1C05/* && gSettingsContext.skipDarmaniCutscene*/) {
+    } else if (gctx->next_entrance == 0x1C05 && gSettingsContext.skipDarmaniCutscene) {
       gctx->next_entrance = 0x9610;
       cdata.sub13s[0].entrance_index = 0x9610;
       didWarp = true;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -45,8 +45,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x56;
     rItemOverrides[1].key.scene = 0x6F;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0x59;
-    rItemOverrides[1].value.looksLikeItemId = 0x59;
+    rItemOverrides[1].value.getItemId = 0x57;
+    rItemOverrides[1].value.looksLikeItemId = 0x57;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -45,8 +45,8 @@ namespace rnd {
     rItemOverrides[0].value.looksLikeItemId = 0x56;
     rItemOverrides[1].key.scene = 0x6F;
     rItemOverrides[1].key.type = ItemOverride_Type::OVR_COLLECTABLE;
-    rItemOverrides[1].value.getItemId = 0x57;
-    rItemOverrides[1].value.looksLikeItemId = 0x57;
+    rItemOverrides[1].value.getItemId = 0x01;
+    rItemOverrides[1].value.looksLikeItemId = 0x01;
     rItemOverrides[2].key.scene = 0x12;
     rItemOverrides[2].key.type = ItemOverride_Type::OVR_COLLECTABLE;
     rItemOverrides[2].value.getItemId = 0x37;

--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -93,7 +93,6 @@ namespace rnd {
         else
           model->scale = 10.00f;
       }
-      model->scale = 10.00f;
       scaleMtx[0][0] = model->scale;
       scaleMtx[1][1] = model->scale;
       scaleMtx[2][2] = model->scale;
@@ -297,7 +296,7 @@ namespace rnd {
     overlayTable[0x99].info->deinit_fn = En_Si_Destroy;
 
     overlayTable[0x12B].info->init_fn = Dm_Char03_Init;
-    // overlayTable[0x12B].info->draw_fn = Dm_Char03_Draw;
+    overlayTable[0x12B].info->draw_fn = Dm_Char03_Draw;
     // overlayTable[0x12D].info->init_fn = DMChar05_Init;
     // overlayTable[0x12D].info->draw_fn = DMChar05_Draw;
     // overlayTable[0x12D].info->init_fn = DMChar05_Init;

--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -1,6 +1,7 @@
 #include "rnd/models.h"
 #include "rnd/actors/dm_hina.h"
-#include "rnd/actors/dmchar05.h"
+#include "rnd/actors/dm_char03.h"
+#include "rnd/actors/dm_char05.h"
 #include "rnd/actors/en_si.h"
 #include "rnd/actors/item00.h"
 #include "rnd/actors/item_b_heart.h"
@@ -295,6 +296,8 @@ namespace rnd {
     overlayTable[0x99].info->draw_fn = En_Si_Draw;
     overlayTable[0x99].info->deinit_fn = En_Si_Destroy;
 
+    overlayTable[0x12B].info->init_fn = Dm_Char03_Init;
+    // overlayTable[0x12B].info->draw_fn = Dm_Char03_Draw;
     // overlayTable[0x12D].info->init_fn = DMChar05_Init;
     // overlayTable[0x12D].info->draw_fn = DMChar05_Draw;
     // overlayTable[0x12D].info->init_fn = DMChar05_Init;

--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -297,8 +297,9 @@ namespace rnd {
 
     overlayTable[0x12B].info->init_fn = Dm_Char03_Init;
     overlayTable[0x12B].info->draw_fn = Dm_Char03_Draw;
-    // overlayTable[0x12D].info->init_fn = DMChar05_Init;
-    // overlayTable[0x12D].info->draw_fn = DMChar05_Draw;
-    // overlayTable[0x12D].info->init_fn = DMChar05_Init;
+
+    overlayTable[0x12D].info->init_fn = DMChar05_Init;
+    overlayTable[0x12D].info->draw_fn = DMChar05_Draw;
+    overlayTable[0x12D].info->deinit_fn = DMChar05_Destroy;
   }
 }  // namespace rnd

--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -92,7 +92,7 @@ namespace rnd {
         else
           model->scale = 10.00f;
       }
-
+      model->scale = 10.00f;
       scaleMtx[0][0] = model->scale;
       scaleMtx[1][1] = model->scale;
       scaleMtx[2][2] = model->scale;
@@ -262,6 +262,17 @@ namespace rnd {
       if (ModelContext[i].actor == actor) {
         actorDrawn = 1;
         Model_Draw(&ModelContext[i]);
+      }
+    }
+    return actorDrawn;
+  }
+
+  void* Model_GetOverrideSaModel(game::act::Actor* actor) {
+    void* actorDrawn = NULL;
+    for (s32 i = 0; i < LOADEDMODELS_MAX; ++i) {
+      if (ModelContext[i].actor == actor) {
+        actorDrawn = ModelContext[i].saModel;
+        break;
       }
     }
     return actorDrawn;

--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -268,11 +268,11 @@ namespace rnd {
     return actorDrawn;
   }
 
-  void* Model_GetOverrideSaModel(game::act::Actor* actor) {
-    void* actorDrawn = NULL;
+  Model* Model_GetOverrideSaModel(game::act::Actor* actor) {
+    Model* actorDrawn = NULL;
     for (s32 i = 0; i < LOADEDMODELS_MAX; ++i) {
       if (ModelContext[i].actor == actor) {
-        actorDrawn = ModelContext[i].saModel;
+        actorDrawn = &ModelContext[i];
         break;
       }
     }

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -116,7 +116,7 @@ namespace rnd {
     saveData.inventory.collect_register.song_of_soaring = 1;
     saveData.inventory.collect_register.song_of_time = 1;
     // saveData.inventory.collect_register.oath_to_order = 1;
-    saveData.inventory.collect_register.song_of_healing = 1;
+    // saveData.inventory.collect_register.song_of_healing = 1;
 
     gSettingsContext.skipBombersMinigame = 1;
     gSettingsContext.freeScarecrow = 1;


### PR DESCRIPTION
This brings in a rough start to the song of healing masks that are obtained throughout the game.

Please note that animations are currently broken, and half the time the item does not actually move, but clips into the ground about halfway after the animation is finished (i.e. Zora mask falling over, Goron Mask falling down from hovering). However, the overhead item model is now properly drawing, and should be properly scaled. 

A new SkeletonAnimation struct has been added which seems to be inline with what's in code, but it is still very incomplete, at least we can grab the matrix from it now.