### PR TITLE
Remove spidertoken override temporarily.

### DIFF
--- a/code/mm.ld
+++ b/code/mm.ld
@@ -296,9 +296,9 @@ SECTIONS{
     *(.patch_ChangeDrawItemIndexSecond)
   }
 
-  .patch_RemoveSkulltulaTokenGetItem 0x233C60 : {
+  /* .patch_RemoveSkulltulaTokenGetItem 0x233C60 : {
     *(.patch_RemoveSkulltulaTokenGetItem)
-  }
+  } */
 
   .patch_ForceSwordUpgradeOnHuman 0x233D88 : {
     *(.patch_ForceSwordUpgradeOnHuman)


### PR DESCRIPTION
Not needed since skullsanity isn't quite ready yet appside.