### PR TITLE
Fix Koume Boat Archery One Last Time

### DIFF
--- a/code/mm.ld
+++ b/code/mm.ld
@@ -638,9 +638,9 @@ SECTIONS{
     *(.patch_HandleOcarinaHooks)
   }
 
-  .patch_RemoveWoodfallClearConditionFromBoatHouse 0x6737E8 : {
+  /* .patch_RemoveWoodfallClearConditionFromBoatHouse 0x6737E8 : {
       *(.patch_RemoveWoodfallClearConditionFromBoatHouse)
-  }
+  } */
 
   . = 0x61CD8C;
 	/* Addr already 4 byte aligned! */

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -289,10 +289,10 @@ RemoveJimWhenExitingHideout_patch:
 @ and should always evaluate to false.
 @ https://github.com/zeldaret/mm/blob/6541532abb5c03088ad67748bbb23965c654127e/src/overlays/actors/ovl_En_Dnh/z_en_dnh.c#L21
 @ https://github.com/zeldaret/mm/blob/main/include/z64msgevent.h#L354
-.section .patch_RemoveWoodfallClearConditionFromBoatHouse
-.global patch_RemoveWoodfallClearConditionFromBoatHouse
-patch_RemoveWoodfallClearConditionFromBoatHouse:
-    .byte 0x0C
+@ .section .patch_RemoveWoodfallClearConditionFromBoatHouse
+@ .global patch_RemoveWoodfallClearConditionFromBoatHouse
+@ patch_RemoveWoodfallClearConditionFromBoatHouse:
+@     .byte 0x0C
 
 .section .patch_loader
 .global loader_patch


### PR DESCRIPTION
The flag for checking if the swamp is cleared is removed on song of time, so this should be fine to leave as it is.