### PR TITLE
Use an ItemOverride call instead of resolving upgrades for progressiv…

### DIFF
--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -193,8 +193,7 @@ namespace rnd {
 
   void Model_LookupByOverride(Model* model, ItemOverride override) {
     if (override.key.all != 0) {
-      u16 itemId = override.value.looksLikeItemId ? override.value.looksLikeItemId : override.value.getItemId;
-      u16 resolvedItemId = ItemTable_ResolveUpgrades(itemId);
+      u16 resolvedItemId = ItemOverride_SetProgressiveItemDraw(override);
       model->itemRow = ItemTable_GetItemRow(resolvedItemId);
     }
   }


### PR DESCRIPTION
…e items.

This prevents progressive items from being given as soon as they are loaded for models.