### PR TITLE
Remove quiver restrictions when giving items in archery mini games.

### DIFF
--- a/code/mm.ld
+++ b/code/mm.ld
@@ -483,8 +483,16 @@ SECTIONS{
     *(.patch_OverrideWalletSpiderHouse)
   }
 
+  .patch_OverrideArcheryTownQuiverLimit 0x3E50B8 : {
+    *(.patch_OverrideArcheryTownQuiverLimit)
+  }
+
   .patch_OverrideQuiverArcheryTown 0x3E50E4 : {
     *(.patch_OverrideQuiverArchery)
+  }
+
+  .patch_OverrideArcheryTownQuiverLimitTwo 0x3EA278 : {
+    *(.patch_OverrideArcheryTownQuiverLimitTwo)
   }
 
   .patch_OverrideQuiverArcherySwamp 0x3EA2B0 : {

--- a/code/source/asm/item_override_patches.s
+++ b/code/source/asm/item_override_patches.s
@@ -62,10 +62,20 @@ patch_RemoveGoronMaskCheckDarmani:
 patch_CheckOshExtData:
     bl hook_CheckOshExtData
 
+.section .patch_OverrideArcheryTownQuiverLimit
+.global patch_OverrideArcheryTownQuiverLimit
+patch_OverrideArcheryTownQuiverLimit:
+    nop
+
 .section .patch_OverrideQuiverArchery
 .global patch_OverrideQuiverArchery
 patch_OverrideQuiverArchery:
     mov r2,#0x47
+
+.section .patch_OverrideArcheryTownQuiverLimitTwo
+.global patch_OverrideArcheryTownQuiverLimitTwo
+patch_OverrideArcheryTownQuiverLimitTwo:
+    nop
 
 .section .patch_OverrideQuiverArcheryTwo
 .global patch_OverrideQuiverArcheryTwo


### PR DESCRIPTION
This should fix people not getting rewards from the games if they already have the largest quiver.