### PR TITLE
Fix: Adjust ExtDataCheck for En_Fsn

### DIFF
--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -451,7 +451,7 @@ namespace rnd {
         gExtSaveData.givenItemChecks.enFsnANMGivenItem = 1;
       } else if (storedGetItemId == GetItemID::GI_LETTER_TO_MAMA) {
         gExtSaveData.givenItemChecks.letterToMamaGiven = 1;
-      } else {
+      } else if (storedGetItemId == GetItemID::GI_MASK_KEATON) {
         gExtSaveData.givenItemChecks.enFsnGivenItem = 1;
       }
     } else if (storedActorId == game::act::Id::NpcEnPm) {


### PR DESCRIPTION
Include a check for EnFsn to ensure that it's the Keaton Mask being given to avoid locking out of a check. This can happen if a person purchases a bomb bag from the Curiosity Shop before visiting the owner in the Laundry Pool to receive the Keaton Mask.