### PR TITLE
feat: Fierce Deity Anywhere

### DIFF
--- a/code/include/rnd/link.h
+++ b/code/include/rnd/link.h
@@ -15,10 +15,19 @@ namespace rnd::link {
   void HandleFastOcarina(game::GlobalContext*);
   void HandleFastArrowSwitch(game::act::Player*);
   void FixFreeCameraReset();
-  extern "C" void AssignSwordForHoneyDarling();
-  extern "C" void RemoveSwordFromHoneyDarling();
-  extern "C" void ResetPlayerForm();
-
+  extern "C" {
+  bool ShouldUseZoraFastSwim();
+  bool SwitchToZoraFastSwim(game::GlobalContext*, game::act::Player*, bool);
+  bool CheckIfMagicAcquired();
+  void HandleFastTransform();
+  u8 ZoraMaskCheck();
+  void SongOfTimeSwordPlacement();
+  void AssignSwordForHoneyDarling();
+  void RemoveSwordFromHoneyDarling();
+  void ResetPlayerForm();
+  u8 UseFDAnywhere();
+  }
+  
 }  // namespace rnd::link
 
 #endif

--- a/code/include/rnd/link.h
+++ b/code/include/rnd/link.h
@@ -29,7 +29,7 @@ namespace rnd::link {
   u8 CheckIfLinkIsFD();
   game::act::Player::Form FierceDeityArcheryFix(game::act::Player::Form);
   }
-  
+
 }  // namespace rnd::link
 
 #endif

--- a/code/include/rnd/link.h
+++ b/code/include/rnd/link.h
@@ -26,6 +26,7 @@ namespace rnd::link {
   void RemoveSwordFromHoneyDarling();
   void ResetPlayerForm();
   u8 UseFDAnywhere();
+  u8 CheckIfLinkIsFD();
   game::act::Player::Form FierceDeityArcheryFix(game::act::Player::Form);
   }
   

--- a/code/include/rnd/link.h
+++ b/code/include/rnd/link.h
@@ -26,6 +26,7 @@ namespace rnd::link {
   void RemoveSwordFromHoneyDarling();
   void ResetPlayerForm();
   u8 UseFDAnywhere();
+  game::act::Player::Form FierceDeityArcheryFix(game::act::Player::Form);
   }
   
 }  // namespace rnd::link

--- a/code/include/rnd/link.h
+++ b/code/include/rnd/link.h
@@ -25,7 +25,7 @@ namespace rnd::link {
   void AssignSwordForHoneyDarling();
   void RemoveSwordFromHoneyDarling();
   void ResetPlayerForm();
-  u8 UseFDAnywhere();
+  game::ItemId UseFDAnywhere(game::ItemId);
   u8 CheckIfLinkIsFD();
   game::act::Player::Form FierceDeityArcheryFix(game::act::Player::Form);
   }

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -434,6 +434,8 @@ namespace rnd {
 
     // Extra MM Settings
     u8 blastMaskCooldown;
+
+    u8 useFierceDeityAnywhere = 1;
   } SettingsContext;
 
   extern "C" SettingsContext gSettingsContext;

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -435,7 +435,7 @@ namespace rnd {
     // Extra MM Settings
     u8 blastMaskCooldown;
 
-    u8 useFierceDeityAnywhere = 1;
+    u8 useFierceDeityAnywhere = 0;
   } SettingsContext;
 
   extern "C" SettingsContext gSettingsContext;

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -61,6 +61,18 @@ SECTIONS{
     *(.patch_OverrideBombersNotebook)
   }
 
+  .patch_UseFDAnywhere 0x1B1248 : {
+    *(.patch_UseFDAnywhere)
+  }
+
+  .patch_FDClimbingAnimationFixOne 0x68DA94 : {
+    *(.patch_FDClimbingAnimationFixOne)
+  }
+
+  .patch_FDClimbingAnimationFixTwo 0x68DAB4 : {
+    *(.patch_FDClimbingAnimationFixTwo)
+  }
+
   .patch_FastTransformPatchOne 0x1EB3B8 : {
     *(.patch_FastTransformPatchOne)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -65,14 +65,6 @@ SECTIONS{
     *(.patch_UseFDAnywhere)
   }
 
-  .patch_FDClimbingAnimationFixOne 0x68DA94 : {
-    *(.patch_FDClimbingAnimationFixOne)
-  }
-
-  .patch_FDClimbingAnimationFixTwo 0x68DAB4 : {
-    *(.patch_FDClimbingAnimationFixTwo)
-  }
-
   .patch_FastTransformPatchOne 0x1EB3B8 : {
     *(.patch_FastTransformPatchOne)
   }
@@ -455,16 +447,20 @@ SECTIONS{
     *(.patch_DmChar05GoronInit)
   } */
 
+  .patch_OverrideRemainSpawn 0x389E7C : {
+    *(.patch_OverrideRemainSpawn)
+  }
+
+  .patch_RemoveWoodfallClearConditionFromBoatHouse 0x39655C : {
+      *(.patch_RemoveWoodfallClearConditionFromBoatHouse)
+  }
+
   .patch_OverrideItem00Init 0x3D018C : {
     *(.patch_OverrideItem00Init)
   }
 
   .patch_DmChar03ModelDraw 0x3B9254 : {
     *(.patch_DmChar03ModelDraw)
-  }
-
-  .patch_OverrideRemainSpawn 0x389E7C : {
-    *(.patch_OverrideRemainSpawn)
   }
 
   .patch_RemainsModelDraw 0x3C7D7C : {
@@ -705,8 +701,28 @@ SECTIONS{
     *(.patch_HandleOcarinaHooks)
   }
 
-  .patch_RemoveWoodfallClearConditionFromBoatHouse 0x39655C : {
-      *(.patch_RemoveWoodfallClearConditionFromBoatHouse)
+  .patch_FDClimbingAnimationFixOne 0x68DA90 : {
+    *(.patch_FDClimbingAnimationFixOne)
+  }
+
+  .patch_FDClimbingAnimationFixTwo 0x68DAB4 : {
+    *(.patch_FDClimbingAnimationFixTwo)
+  }
+
+  .patch_FDDoorCrashOne 0x68E0E4 : {
+    *(.patch_FDDoorCrashOne)
+  }
+
+  .patch_FDDoorCrashTwo 0x68E0F0 : {
+    *(.patch_FDDoorCrashTwo)
+  }
+
+  .patch_FDDoorCrashThree 0x68E114 : {
+    *(.patch_FDDoorCrashThree)
+  }
+
+  .patch_FDDoorCrashFour 0x68E120 : {
+    *(.patch_FDDoorCrashFour)
   }
 
   . = 0x61CD8C;

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -359,6 +359,10 @@ SECTIONS{
     *(.patch_GiveTempSwordForHandD)
   }
 
+  .patch_CheckIfLinkIsFD 0x2C91D4 : {
+    *(.patch_CheckIfLinkIsFD)
+  }
+
   .patch_GaboraCheckExtDataNotSword 0x2CBB14 : {
     *(.patch_GaboraCheckExtDataNotSword)
   }
@@ -410,6 +414,14 @@ SECTIONS{
   /* .patch_RemoveSkulltulaSpawnIfCollectedItem 0x2E8384 : {
     *(.patch_RemoveSkulltulaSpawnIfCollectedItem)
   } */
+
+  .patch_FixFDObservatoryText 0x30A3B0 : {
+    *(.patch_FixFDObservatoryText)
+  }
+
+  .patch_FixFDObservatoryTextTwo 0x30A4A0 : {
+    *(.patch_FixFDObservatoryTextTwo)
+  }
 
   .patch_SaveExtDataOnOwl 0x317004 : {
     *(.patch_SaveExtDataOnOwl)

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -583,6 +583,10 @@ SECTIONS{
     *(.patch_OverrideItem00Draw)
   }
 
+  .patch_FierceDeityArcheryFix 0x4427E8 : {
+    *(.patch_FierceDeityArcheryFix)
+  }
+
   .patch_OverrideBankerWalletReward 0x459044 : {
     *(.patch_OverrideProgessiveWalletTwo)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -705,6 +705,10 @@ SECTIONS{
     *(.patch_HandleOcarinaHooks)
   }
 
+  .patch_FDOpenDungeonDoors 0x68D9C0 : {
+    *(.patch_FDOpenDungeonDoors)
+  }
+
   .patch_FDClimbingAnimationFixOne 0x68DA90 : {
     *(.patch_FDClimbingAnimationFixOne)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -61,7 +61,7 @@ SECTIONS{
     *(.patch_OverrideBombersNotebook)
   }
 
-  .patch_UseFDAnywhere 0x1B1248 : {
+  .patch_UseFDAnywhere 0x1B1244 : {
     *(.patch_UseFDAnywhere)
   }
 

--- a/code/source/asm/fd_hooks.s
+++ b/code/source/asm/fd_hooks.s
@@ -1,0 +1,13 @@
+.arm
+.text
+
+.global hook_UseFDAnywhere
+hook_UseFDAnywhere:
+  push {r0-r12, lr}
+  bl UseFDAnywhere @ found in link.cpp
+  cmp r0, #0x0
+  pop {r0-r12,lr}
+  beq doNotUseFdAnywhere
+  bx lr
+doNotUseFdAnywhere:
+  b 0x1B1354

--- a/code/source/asm/fd_hooks.s
+++ b/code/source/asm/fd_hooks.s
@@ -4,12 +4,11 @@
 .global hook_UseFDAnywhere
 hook_UseFDAnywhere:
   push {r0-r12, lr}
+  mov r0, r3
   bl UseFDAnywhere @ found in link.cpp
   cmp r0, #0x35
   pop {r0-r12,lr}
-  beq 0x1b1354
-  cmp r3, #0x00
-  b 0x1B124C
+  b 0x1B1248
 
 .global hook_CheckIfLinkIsFD
 hook_CheckIfLinkIsFD:

--- a/code/source/asm/fd_hooks.s
+++ b/code/source/asm/fd_hooks.s
@@ -5,9 +5,16 @@
 hook_UseFDAnywhere:
   push {r0-r12, lr}
   bl UseFDAnywhere @ found in link.cpp
-  cmp r0, #0x0
+  cmp r0, #0x35
   pop {r0-r12,lr}
-  beq doNotUseFdAnywhere
+  beq 0x1b1354
+  cmp r3, #0x00
   bx lr
-doNotUseFdAnywhere:
-  b 0x1B1354
+
+.global hook_FierceDeityArcheryFix
+hook_FierceDeityArcheryFix:
+  push {r0-r12, lr}
+  bl FierceDeityArcheryFix @ found in link.cpp
+  cmp r0, #0x3
+  pop {r0-r12,lr}
+  bx lr

--- a/code/source/asm/fd_hooks.s
+++ b/code/source/asm/fd_hooks.s
@@ -9,7 +9,7 @@ hook_UseFDAnywhere:
   pop {r0-r12,lr}
   beq 0x1b1354
   cmp r3, #0x00
-  bx lr
+  b 0x1B124C
 
 .global hook_FierceDeityArcheryFix
 hook_FierceDeityArcheryFix:

--- a/code/source/asm/fd_hooks.s
+++ b/code/source/asm/fd_hooks.s
@@ -11,6 +11,42 @@ hook_UseFDAnywhere:
   cmp r3, #0x00
   b 0x1B124C
 
+.global hook_CheckIfLinkIsFD
+hook_CheckIfLinkIsFD:
+  push {r0-r12, lr}
+  bl CheckIfLinkIsFD @ found in link.cpp
+  cmp r0, #0x1
+  pop {r0-r12,lr}
+  beq 0x2C921C
+  cmp r0, #0x1
+  cmpne r0, #0x2
+  beq 0x2C921C
+  bx lr
+
+.global hook_FixFDObservatoryText
+hook_FixFDObservatoryText:
+  push {r0-r12, lr}
+  bl CheckIfLinkIsFD @ found in link.cpp
+  cmp r0, #0x1
+  pop {r0-r12,lr}
+  beq 0x30A440
+  cmp r0, #0x2
+  cmpne r0, #0x3
+  beq 0x30A440
+  bx lr
+
+.global hook_FixFDObservatoryTextTwo
+hook_FixFDObservatoryTextTwo:
+  push {r0-r12, lr}
+  bl CheckIfLinkIsFD @ found in link.cpp
+  cmp r0, #0x1
+  pop {r0-r12,lr}
+  beq 0x30A4F4
+  cmp r0, #0x2
+  cmpne r0, #0x3
+  beq 0x30A4F4
+  bx lr
+
 .global hook_FierceDeityArcheryFix
 hook_FierceDeityArcheryFix:
   push {r0-r12, lr}

--- a/code/source/asm/fd_patches.s
+++ b/code/source/asm/fd_patches.s
@@ -1,0 +1,22 @@
+.arm
+
+.section .patch_UseFDAnywhere
+.global patch_UseFDAnywhere
+patch_UseFDAnywhere:
+  bl hook_UseFDAnywhere
+
+.section .patch_FDClimbingAnimationFixOne
+.global patch_FDClimbingAnimationFixOne
+patch_FDClimbingAnimationFixOne:
+  .word 0x1F9
+  .word 0x1FA
+  .word 0x1FB
+  .word 0x1FC
+
+
+.section .patch_FDClimbingAnimationFixTwo
+.global patch_FDClimbingAnimationFixTwo
+patch_FDClimbingAnimationFixTwo:
+  .word 0x1F5
+  .word 0x1F5
+  .word 0x1F8

--- a/code/source/asm/fd_patches.s
+++ b/code/source/asm/fd_patches.s
@@ -3,7 +3,12 @@
 .section .patch_UseFDAnywhere
 .global patch_UseFDAnywhere
 patch_UseFDAnywhere:
-  bl hook_UseFDAnywhere
+  bleq hook_UseFDAnywhere
+
+.section .patch_FierceDeityArcheryFix
+.global patch_FierceDeityArcheryFix
+patch_FierceDeityArcheryFix:
+  bl hook_FierceDeityArcheryFix
 
 .section .patch_FDClimbingAnimationFixOne
 .global patch_FDClimbingAnimationFixOne

--- a/code/source/asm/fd_patches.s
+++ b/code/source/asm/fd_patches.s
@@ -8,6 +8,7 @@ patch_UseFDAnywhere:
 .section .patch_FDClimbingAnimationFixOne
 .global patch_FDClimbingAnimationFixOne
 patch_FDClimbingAnimationFixOne:
+  .word 0x338
   .word 0x1F9
   .word 0x1FA
   .word 0x1FB
@@ -20,3 +21,23 @@ patch_FDClimbingAnimationFixTwo:
   .word 0x1F5
   .word 0x1F5
   .word 0x1F8
+
+.section .patch_FDDoorCrashOne
+.global patch_FDDoorCrashOne
+patch_FDDoorCrashOne:
+  .word 0x2BD
+
+.section .patch_FDDoorCrashTwo
+.global patch_FDDoorCrashTwo
+patch_FDDoorCrashTwo:
+  .word 0x2BD
+
+.section .patch_FDDoorCrashThree
+.global patch_FDDoorCrashThree
+patch_FDDoorCrashThree:
+  .word 0x2BE
+
+.section .patch_FDDoorCrashFour
+.global patch_FDDoorCrashFour
+patch_FDDoorCrashFour:
+  .word 0x2BE

--- a/code/source/asm/fd_patches.s
+++ b/code/source/asm/fd_patches.s
@@ -3,12 +3,17 @@
 .section .patch_UseFDAnywhere
 .global patch_UseFDAnywhere
 patch_UseFDAnywhere:
-  bleq hook_UseFDAnywhere
+  b hook_UseFDAnywhere
 
 .section .patch_FierceDeityArcheryFix
 .global patch_FierceDeityArcheryFix
 patch_FierceDeityArcheryFix:
   bl hook_FierceDeityArcheryFix
+
+.section .patch_FDOpenDungeonDoors
+.global patch_FDOpenDungeonDoors
+patch_FDOpenDungeonDoors:
+  .word 0x416
 
 .section .patch_FDClimbingAnimationFixOne
 .global patch_FDClimbingAnimationFixOne

--- a/code/source/asm/fd_patches.s
+++ b/code/source/asm/fd_patches.s
@@ -5,6 +5,21 @@
 patch_UseFDAnywhere:
   b hook_UseFDAnywhere
 
+.section .patch_CheckIfLinkIsFD
+.global patch_CheckIfLinkIsFD
+patch_CheckIfLinkIsFD:
+  bl hook_CheckIfLinkIsFD
+
+.section .patch_FixFDObservatoryText
+.global patch_FixFDObservatoryText
+patch_FixFDObservatoryText:
+  bl hook_FixFDObservatoryText
+
+.section .patch_FixFDObservatoryTextTwo
+.global patch_FixFDObservatoryTextTwo
+patch_FixFDObservatoryTextTwo:
+  bl hook_FixFDObservatoryTextTwo
+
 .section .patch_FierceDeityArcheryFix
 .global patch_FierceDeityArcheryFix
 patch_FierceDeityArcheryFix:

--- a/code/source/rnd/link.cpp
+++ b/code/source/rnd/link.cpp
@@ -403,6 +403,16 @@ namespace rnd::link {
     return 0x32;  // Enabled, allow Fierce Deity to be used anywhere.
   }
 
+  u8 CheckIfLinkIsFD() {
+    game::SaveData& saveData = game::GetCommonData().save;
+    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: Form is %u\n", __func__, static_cast<u8>(saveData.player_form));	
+    #endif
+    if (saveData.player_form == game::act::Player::Form::FierceDeity)
+      return 1;
+    return 0;
+  }
+
   game::act::Player::Form FierceDeityArcheryFix(game::act::Player::Form form) {
     if (form == game::act::Player::Form::FierceDeity || form == game::act::Player::Form::Deku)
       return game::act::Player::Form::Deku;

--- a/code/source/rnd/link.cpp
+++ b/code/source/rnd/link.cpp
@@ -394,13 +394,15 @@ namespace rnd::link {
     }
   }
 
-  u8 UseFDAnywhere() {
-    // This function is called from the ASM patch.
-    // It checks if the option is enabled to use Fierce Deity outside of boss fights.
-    if (gSettingsContext.useFierceDeityAnywhere == 0) {
-      return 0x35;  // Not enabled, do nothing.
-    }
-    return 0x32;  // Enabled, allow Fierce Deity to be used anywhere.
+  game::ItemId UseFDAnywhere(game::ItemId itemId) {
+    if (itemId == game::ItemId::FierceDeityMask) {
+      // This function is called from the ASM patch.
+      // It checks if the option is enabled to use Fierce Deity outside of boss fights.
+      if (gSettingsContext.useFierceDeityAnywhere == 0)
+        return game::ItemId::FierceDeityMask;  // Not enabled, do nothing.
+      return game::ItemId::Ocarina;            // Enabled, allow Fierce Deity to be used anywhere.
+    } else
+      return itemId;
   }
 
   u8 CheckIfLinkIsFD() {

--- a/code/source/rnd/link.cpp
+++ b/code/source/rnd/link.cpp
@@ -393,6 +393,15 @@ namespace rnd::link {
       saveData.player_form = game::act::Player::Form::Human;
     }
   }
+
+  u8 UseFDAnywhere() {
+    // This function is called from the ASM patch.
+    // It checks if the option is enabled to use Fierce Deity outside of boss fights.
+    if (gSettingsContext.useFierceDeityAnywhere == 0) {
+      return 0;  // Not enabled, do nothing.
+    }
+    return 1;  // Enabled, allow Fierce Deity to be used anywhere.
   }
+}
 
 }  // namespace rnd::link

--- a/code/source/rnd/link.cpp
+++ b/code/source/rnd/link.cpp
@@ -405,9 +405,6 @@ namespace rnd::link {
 
   u8 CheckIfLinkIsFD() {
     game::SaveData& saveData = game::GetCommonData().save;
-    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-      rnd::util::Print("%s: Form is %u\n", __func__, static_cast<u8>(saveData.player_form));	
-    #endif
     if (saveData.player_form == game::act::Player::Form::FierceDeity)
       return 1;
     return 0;
@@ -418,7 +415,6 @@ namespace rnd::link {
       return game::act::Player::Form::Deku;
     return form;
   }
-  
-}
+  }
 
 }  // namespace rnd::link

--- a/code/source/rnd/link.cpp
+++ b/code/source/rnd/link.cpp
@@ -398,10 +398,17 @@ namespace rnd::link {
     // This function is called from the ASM patch.
     // It checks if the option is enabled to use Fierce Deity outside of boss fights.
     if (gSettingsContext.useFierceDeityAnywhere == 0) {
-      return 0;  // Not enabled, do nothing.
+      return 0x35;  // Not enabled, do nothing.
     }
-    return 1;  // Enabled, allow Fierce Deity to be used anywhere.
+    return 0x32;  // Enabled, allow Fierce Deity to be used anywhere.
   }
+
+  game::act::Player::Form FierceDeityArcheryFix(game::act::Player::Form form) {
+    if (form == game::act::Player::Form::FierceDeity || form == game::act::Player::Form::Deku)
+      return game::act::Player::Form::Deku;
+    return form;
+  }
+  
 }
 
 }  // namespace rnd::link


### PR DESCRIPTION
This latest PR includes a new option to enable Fierce Deity anywhere in the overworld. There have been some patches included to ensure regular talking will not soft lock. There will most likely exist a handful of NPCs that will still softlock you (i.e. Jim) if you end up talking to him as FD.

However, this should be good for a first initial pass through and we should be able to get some more info on NPCs that continue to crash. For this reason, this PR will remain open for any fixes that we need to apply.