### PR TITLE
feat: Remove ocarina from inventory without initiating first cycle

### DIFF
--- a/code/include/rnd/link.h
+++ b/code/include/rnd/link.h
@@ -27,6 +27,7 @@ namespace rnd::link {
   void ResetPlayerForm();
   game::ItemId UseFDAnywhere(game::ItemId);
   u8 CheckIfLinkIsFD();
+  u8 CheckIfOcarinaIsInInventory();
   game::act::Player::Form FierceDeityArcheryFix(game::act::Player::Form);
   }
 

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -233,6 +233,10 @@ SECTIONS{
     *(.patch_CheckMagicForZoraFastSwim)
   }
 
+  .patch_FixRemovingOcarinaFromInventory 0x201064 : {
+    *(.patch_FixRemovingOcarinaFromInventory)
+  }
+
   .patch_storeObjectIdForExtendedObject 0x203C44 : {
     *(.patch_storeObjectIdForExtendedObject)
   }
@@ -664,6 +668,10 @@ SECTIONS{
     *(.patch_SkulltulaOverrideTwo)
   }
 
+  .patch_UpdateOcarinaVisibility 0x59AA2C : {
+    *(.patch_UpdateOcarinaVisibility)
+  }
+
   .patch_ReadGamePad 0x59BA10 : {
     *(.patch_ReadGamePad)
   }
@@ -672,7 +680,7 @@ SECTIONS{
     *(.patch_DisableExistingTrigger)
   }
 
-  .patch_SwapStoredTradeItems 0x5a6b44 : {
+  .patch_SwapStoredTradeItems 0x5A6b44 : {
     *(.patch_SwapStoredTradeItems)
   }
 

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -298,7 +298,25 @@ hook_RemoveWoodfallClearConditionFromBoatHouse:
     pop {r0-r12,lr}
     cmp r0,#0x2
     bx lr
+
+.global hook_FixRemovingOcarinaFromInventory
+hook_FixRemovingOcarinaFromInventory:
+    cmp r0,#0x0
+    beq ocarinaAlwaysInInventory
+    add r0,r0,r1 @ original instruction
+    b 0x201068
+ocarinaAlwaysInInventory:
+    mov r0, #0x0 @ Force the ocarina to always be in inventory
+    b 0x20106C
     
+.global hook_UpdateOcarinaVisibility
+hook_UpdateOcarinaVisibility:
+    push {r0-r5, r7-r12,lr}
+    bl CheckIfOcarinaIsInInventory
+    subs r6,r0,#0xFF
+    pop {r0-r5, r7-r12,lr}
+    bx lr
+
 .section .loader
 .global hook_into_loader
 hook_into_loader:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -282,6 +282,16 @@ patch_CheckMasksOnMoon:
 RemoveJimWhenExitingHideout_patch:
     cmp r0,r0
 
+.section .patch_FixRemovingOcarinaFromInventory
+.global patch_FixRemovingOcarinaFromInventory
+patch_FixRemovingOcarinaFromInventory:
+    b hook_FixRemovingOcarinaFromInventory
+
+.section .patch_UpdateOcarinaVisibility
+.global patch_UpdateOcarinaVisibility
+patch_UpdateOcarinaVisibility:
+    bl hook_UpdateOcarinaVisibility
+
 @ This patch performs the same event check to see if Koume was saved,
 @ overriding the check to see if woodfall was cleared. This is due
 @ to the fact you could beat the temple out of logic from saving koume

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -107,10 +107,11 @@ namespace rnd {
 // const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     if (pressedButtons == (u32)game::pad::Button::ZR) {
-      gExtSaveData.givenItemChecks.odolwaDefeated = 1;
-      yPos += 10.00f;
+      auto& inventory = game::GetCommonData().save.inventory;
+      inventory.items[0] = game::ItemId::None;
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
-      yPos -= 10.00f;
+      auto& inventory = game::GetCommonData().save.inventory;
+      inventory.items[0] = game::ItemId::Ocarina;
     } else if (pressedButtons == (u32)game::pad::Button::Right) {
       xPos += 10.00f;
     } else if (pressedButtons == (u32)game::pad::Button::Left) {

--- a/code/source/rnd/link.cpp
+++ b/code/source/rnd/link.cpp
@@ -417,6 +417,16 @@ namespace rnd::link {
       return game::act::Player::Form::Deku;
     return form;
   }
+
+  u8 CheckIfOcarinaIsInInventory() {
+    // XXX: This function replaces vanilla checks in the update buttons as we are blanket converting
+    // to ensure we always have the ocarina in the inventory according to the game.
+    // This is only for visual updates in the lower screen.
+    game::SaveData& saveData = game::GetCommonData().save;
+    if (saveData.inventory.items[0] == game::ItemId::Ocarina)
+      return 0;
+    return 0xFF;
+  }
   }
 
 }  // namespace rnd::link


### PR DESCRIPTION
This should technically allow a user to play second cycle without an ocarina, time should flow normally and everyone will assume you have ocarina.