### PR TITLE
fix: Convert week event regs to bitfields.

### DIFF
--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -15,6 +15,7 @@
 #include "common/utils.h"
 #include "game/items.h"
 #include "game/player.h"
+#include "game/weekeventreg.h"
 #include "z3d/z3DVec.h"
 
 namespace game {
@@ -327,204 +328,149 @@ namespace game {
     u16 anonymous_67;
     int anonymous_68;
     u8 gap1244[4];
-    union CameraPanningEventFlags {
-      u32 raw;
+    // From here (0x1245) to 0x12a9 is the weekEventReg. 
+    // Conver to bitfields and adopt the weekeventreg name.
+    WeekEventReg00 week_event_reg_00;
+    WeekEventReg01 week_event_reg_01;
+    WeekEventReg02 week_event_reg_02;
+    WeekEventReg03 week_event_reg_03;
+    WeekEventReg04 week_event_reg_04;
+    WeekEventReg05 week_event_reg_05;
+    WeekEventReg06 week_event_reg_06;
+    WeekEventReg07 week_event_reg_07;
+    WeekEventReg08 week_event_reg_08;
+    WeekEventReg09 week_event_reg_09;
+    WeekEventReg10 week_event_reg_10;
+    WeekEventReg11 week_event_reg_11;
+    WeekEventReg12 week_event_reg_12;
+    WeekEventReg13 week_event_reg_13;
+    WeekEventReg14 week_event_reg_14;
+    WeekEventReg15 week_event_reg_15;
+    WeekEventReg16 week_event_reg_16;
+    WeekEventReg17 week_event_reg_17;
+    WeekEventReg18 week_event_reg_18;
+    WeekEventReg19 week_event_reg_19;
+    WeekEventReg20 week_event_reg_20;
+    WeekEventReg21 week_event_reg_21;
+    WeekEventReg22 week_event_reg_22;
+    WeekEventReg23 week_event_reg_23;
+    WeekEventReg24 week_event_reg_24;
+    WeekEventReg25 week_event_reg_25;
+    WeekEventReg26 week_event_reg_26;
+    WeekEventReg27 week_event_reg_27;
+    WeekEventReg28 week_event_reg_28;
+    WeekEventReg29 week_event_reg_29;
+    WeekEventReg30 week_event_reg_30;
+    WeekEventReg31 week_event_reg_31;
+    WeekEventReg32 week_event_reg_32;
+    WeekEventReg33 week_event_reg_33;
+    WeekEventReg34 week_event_reg_34;
+    WeekEventReg35 week_event_reg_35;
+    WeekEventReg36 week_event_reg_36;
+    WeekEventReg37 week_event_reg_37;
+    WeekEventReg38 week_event_reg_38;
+    WeekEventReg39 week_event_reg_39;
+    WeekEventReg40 week_event_reg_40;
+    WeekEventReg41 week_event_reg_41;
+    WeekEventReg42 week_event_reg_42;
+    WeekEventReg43 week_event_reg_43;
+    WeekEventReg44 week_event_reg_44;
+    WeekEventReg45 week_event_reg_45;
+    WeekEventReg46 week_event_reg_46;
+    WeekEventReg47 week_event_reg_47;
+    WeekEventReg48 week_event_reg_48;
+    WeekEventReg49 week_event_reg_49;
+    WeekEventReg50 week_event_reg_50;
+    WeekEventReg51 week_event_reg_51;
+    WeekEventReg52 week_event_reg_52;
+    WeekEventReg53 week_event_reg_53;
+    WeekEventReg54 week_event_reg_54;
+    WeekEventReg55 week_event_reg_55;
+    WeekEventReg56 week_event_reg_56;
+    WeekEventReg57 week_event_reg_57;
+    WeekEventReg58 week_event_reg_58;
+    WeekEventReg59 week_event_reg_59;
+    WeekEventReg60 week_event_reg_60;
+    WeekEventReg61 week_event_reg_61;
+    WeekEventReg62 week_event_reg_62;
+    WeekEventReg63 week_event_reg_63;
+    WeekEventReg64 week_event_reg_64;
+    WeekEventReg65 week_event_reg_65;
+    WeekEventReg66 week_event_reg_66;
+    WeekEventReg67 week_event_reg_67;
+    WeekEventReg68 week_event_reg_68;
+    WeekEventReg69 week_event_reg_69;
+    WeekEventReg70 week_event_reg_70;
+    WeekEventReg71 week_event_reg_71;
+    WeekEventReg72 week_event_reg_72;
+    WeekEventReg73 week_event_reg_73;
+    WeekEventReg74 week_event_reg_74;
+    WeekEventReg75 week_event_reg_75;
+    WeekEventReg76 week_event_reg_76;
+    WeekEventReg77 week_event_reg_77;
+    WeekEventReg78 week_event_reg_78;
+    WeekEventReg79 week_event_reg_79;
+    WeekEventReg80 week_event_reg_80;
+    WeekEventReg81 week_event_reg_81;
+    WeekEventReg82 week_event_reg_82;
+    WeekEventReg83 week_event_reg_83;
+    WeekEventReg84 week_event_reg_84;
+    WeekEventReg85 week_event_reg_85;
+    WeekEventReg86 week_event_reg_86;
+    WeekEventReg87 week_event_reg_87;
+    WeekEventReg88 week_event_reg_88;
+    WeekEventReg89 week_event_reg_89;
+    WeekEventReg90 week_event_reg_90;
+    WeekEventReg91 week_event_reg_91;
+    WeekEventReg92 week_event_reg_92;
+    WeekEventReg93 week_event_reg_93;
+    WeekEventReg94 week_event_reg_94;
+    WeekEventReg95 week_event_reg_95;
+    WeekEventReg96 week_event_reg_96;
+    WeekEventReg97 week_event_reg_97;
+    WeekEventReg98 week_event_reg_98;
+    WeekEventReg99 week_event_reg_99;
+    WeekEventReg100 week_event_reg_100;
+    WeekEventReg101 week_event_reg_101;
+    WeekEventReg102 week_event_reg_102;
+    WeekEventReg103 week_event_reg_103;
+    WeekEventReg104 week_event_reg_104;
+    WeekEventReg105 week_event_reg_105;
+    WeekEventReg106 week_event_reg_106;
+    WeekEventReg107 week_event_reg_107;
+    WeekEventReg108 week_event_reg_108;
+    WeekEventReg109 week_event_reg_109;
+    WeekEventReg110 week_event_reg_110;
+    WeekEventReg111 week_event_reg_111;
+    WeekEventReg112 week_event_reg_112;
+    WeekEventReg113 week_event_reg_113;
+    WeekEventReg114 week_event_reg_114;
+    WeekEventReg115 week_event_reg_115;
+    WeekEventReg116 week_event_reg_116;
+    WeekEventReg117 week_event_reg_117;
+    WeekEventReg118 week_event_reg_118;
+    WeekEventReg119 week_event_reg_119;
+    WeekEventReg120 week_event_reg_120;
+    WeekEventReg121 week_event_reg_121;
+    WeekEventReg122 week_event_reg_122;
+    WeekEventReg123 week_event_reg_123;
+    WeekEventReg124 week_event_reg_124;
+    WeekEventReg125 week_event_reg_125;
+    WeekEventReg126 week_event_reg_126;
+    WeekEventReg127 week_event_reg_127;
+    WeekEventReg128 week_event_reg_128;
+    WeekEventReg129 week_event_reg_129;
+    WeekEventReg130 week_event_reg_130;
+    WeekEventReg131 week_event_reg_131;
+    WeekEventReg132 week_event_reg_132;
+    WeekEventReg133 week_event_reg_133;
+    WeekEventReg134 week_event_reg_134;
+    WeekEventReg135 week_event_reg_135;
+    WeekEventReg136 week_event_reg_136;
+    WeekEventReg137 week_event_reg_137;
+    WeekEventReg138 week_event_reg_138;
+    WeekEventReg139 week_event_reg_139;
 
-      BitField<0, 1, u32> unknown1;
-      BitField<1, 1, u32> termina_field;
-      BitField<2, 1, u32> graveyard;
-      BitField<3, 1, u32> romani_ranch;
-      BitField<4, 2, u32> gorman_track;
-      BitField<5, 1, u32> mountain_village;
-      BitField<6, 1, u32> goron_city;
-      BitField<7, 1, u32> snowhead;
-
-      BitField<8, 1, u32> southern_swamp;
-      BitField<9, 1, u32> woodfall;
-      BitField<10, 1, u32> deku_palace;
-      BitField<11, 1, u32> great_bay_coast;
-      BitField<12, 1, u32> pirates_fortress_interior;
-      BitField<13, 1, u32> zora_domain;
-      BitField<14, 1, u32> waterfall_rapids;
-      BitField<15, 1, u32> ikana_canyon;
-
-      BitField<16, 1, u32> unknown2;
-      BitField<17, 1, u32> stone_tower;
-      BitField<18, 1, u32> stone_tower_inverted;
-      BitField<19, 1, u32> east_clock_town;
-      BitField<20, 1, u32> west_clock_town;
-      BitField<21, 1, u32> north_clock_town;
-      BitField<22, 1, u32> woodfall_temple;
-      BitField<23, 1, u32> snowhead_temple_entry_room;
-
-      BitField<24, 1, u32> unknown3;
-      BitField<25, 1, u32> stone_tower_temple;
-      BitField<26, 1, u32> stone_tower_temple_inverted;
-      BitField<27, 5, u32> unknown4;
-    };
-    CameraPanningEventFlags camera_panning_event_flag_bundle;
-    u8 gap124C[3];
-    char tatl_apology_dialogue_post_Odolwa_0x80;
-    char anonymous_72;
-    char anonymous_73;
-    u8 skip_tingle_intro_dialogue_0x01;
-    char anonymous_75;  // Possible 0x80 if collected fairy from clock town.
-    u8 ct_guard_allows_through_if_0x20;
-    char anonymous_77;
-    u8 flag_8_for_no_magic_use;
-    char anonymous_78;
-    char anonymous_79;
-    u8 ct_deku_removed_if_c0;
-    char anonymous_81;
-    char anonymous_82;
-    u8 open_woodfall_temple_if_0x01;
-    char anonymous_84;
-    char anonymous_85;
-    u8 has_great_spin_0x02;
-    char anonymous_87;
-    char anonymous_88;
-    char anonymous_89;
-    char anonymous_90;
-    char anonymous_91;
-    char anonymous_92;
-    union HaveWornMasks {
-      u8 raw;
-
-      BitField<0, 1, u8> open_snowhead_temple;
-      BitField<1, 3, u8> unknown;
-      BitField<4, 1, u8> has_worn_deku_mask_once;
-      BitField<5, 1, u8> has_worn_goron_mask_once;
-      BitField<6, 1, u8> has_worn_zora_mask_once;
-      BitField<7, 1, u8> has_worn_deity_mask_once;
-    };
-    HaveWornMasks have_worn_mask_once;
-    union AdditonalTatlDialogueFlags {
-      u8 raw;
-
-      BitField<0, 1, u8> have_not_finished_mountain;
-      BitField<1, 1, u8> have_not_finished_ocean;
-      BitField<2, 1, u8> go_south;
-      BitField<3, 5, u8> unknown;
-    };
-    AdditonalTatlDialogueFlags tatl_dialogue_flags2;
-    char anonymous_95;
-    char anonymous_96;
-    char anonymous_97;
-    u8 overworld_map_get_flags_0x3F_for_all;
-    char anonymous_99;
-    u8 anonymous_100_0x10_if_rock_sirloin_spawned;
-    char anonymous_101;
-    char anonymous_102;
-    char anonymous_103;
-    char anonymous_104;
-    u8 gap1272[8];
-    char anonymous_105;
-    char anonymous_106;
-    char anonymous_107;
-    union GreatBayEventFlags {
-      u8 raw;
-
-      BitField<0, 5, u8> unknown1;
-      BitField<5, 1, u8> open_great_bay_temple;
-      BitField<6, 1, u8> skip_swimming_to_great_bay_temple_cutscene;
-      BitField<7, 1, u8> unknown2;
-    };
-    GreatBayEventFlags turtle_flags;
-    char anonymous_109;
-    char anonymous_110;
-    char anonymous_111;
-    char anonymous_112;
-    char anonymous_113;
-    u8 skip_tatl_talking_0x04;  // also has bank reward flags
-    char anonymous_115;
-    u8 swamp_deku_removed_if_0x10;  // Don Gero Flag Maybe
-    char anonymous_117;
-    char anonymous_118;
-    char anonymous_119;
-    char anonymous_120;
-    u8 gap128A[7];
-    union ClockTownResetFlags {
-      u8 raw;
-
-      BitField<0, 2, u8> unknown1;
-      BitField<2, 1, u8> ct_deku_in_flower_if_present;
-      BitField<2, 4, u8> unknown2;
-      BitField<7, 1, u8> bomber_open_hideout;
-    };
-    ClockTownResetFlags clock_town_temp_flags;
-    char anonymous_122;
-    u8 anju_0x10_if_obtained_small_key;
-    char anonymous_124;
-    char grotto_stones_bitflag;
-    char anonymous_126;
-    u8 removes_scarecrow_from_shop_0x08;
-    char anonymous_128;  // Possibly more Cutscene flags
-    char anonymous_129;
-    char anonymous_130;
-    char anonymous_131;
-    char anonymous_132;
-    char anonymous_133;
-    char anonymous_134;
-    // talt dialogue on where to go next after beating a dungeon
-    union TatlDialogueFlags {
-      u8 raw;
-
-      BitField<0, 4, u8> unknown;
-      BitField<4, 1, u8> go_north;
-      BitField<5, 1, u8> go_west;
-      BitField<6, 1, u8> go_east;
-      BitField<7, 1, u8> go_to_skullkid;
-    };
-    TatlDialogueFlags tatl_dialogue_direction_to_go;
-    u8 mikau_pushed_to_shore_0x10;
-    char anonymous_137;
-    char gossip_stone_give_heartpiece_bitflag;
-    u8 mikau_dialogue_flags_0x03;
-    char anonymous_140;
-    char anonymous_141;
-    u8 SoH_Talked_To_Actor_Bitflag;
-    u8 gap12A7[5];
-    char anonymous_142;
-    char anonymous_143;
-    char anonymous_144;
-    u8 gap12AF[3];
-    char anonymous_145;
-    char anonymous_146;
-    u8 gap12B4[13];
-    char anonymous_147;
-    char anonymous_148[6];
-    char anonymous_149;
-    char anonymous_150;
-    u8 activate_dungeon_skip_portal_0xF0_for_all;
-    union CutSceneFlags {
-      u8 raw;
-
-      BitField<0, 1, u8> owl_statue_cut_scene;
-      BitField<1, 2, u8> unknown1;
-      BitField<3, 1, u8> map_tutorial_by_tingle;
-      BitField<4, 2, u8> deku_palace_throne_room_camera_pan;
-      BitField<5, 1, u8> tatl_moon_tear_dialogue;
-      BitField<6, 2, u8> unknown2;
-    };
-    CutSceneFlags cut_scene_flag_bundle;
-    char anonymous_153;
-    u8 dungeon_skip_portal_cutscene_0x3C_to_skip_all;
-    char anonymous_155;
-    char anonymous_156;
-    char anonymous_157;
-    u8 road_to_woodfall_camera_pan_0x08;
-    union OpenedTempleFlags {
-      u8 raw;
-
-      BitField<0, 3, u8> unknown1;
-      BitField<3, 1, u8> played_song_of_soaring_at_least_once;
-      BitField<4, 1, u8> woodfall_temple_opened_at_least_once;
-      BitField<5, 1, u8> snowhead_temple_opened_at_least_once;
-      BitField<6, 1, u8> greatbay_temple_opened_at_least_once;
-      BitField<7, 1, u8> deku_flown_in_at_least_once;
-    };
-    OpenedTempleFlags opened_temple_once_flags;
-    char anonymous_160;
     u8 gap12D4[20];
     // Possibly flags for locations visted or game progression counter
     // Did not affect cutscenes

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -328,7 +328,7 @@ namespace game {
     u16 anonymous_67;
     int anonymous_68;
     u8 gap1244[4];
-    // From here (0x1245) to 0x12a9 is the weekEventReg. 
+    // From here (0x1245) to 0x12a9 is the weekEventReg.
     // Conver to bitfields and adopt the weekeventreg name.
     WeekEventReg00 week_event_reg_00;
     WeekEventReg01 week_event_reg_01;
@@ -530,6 +530,9 @@ namespace game {
   };
   static_assert(sizeof(SaveData) == 0x1A88);
   static_assert(offsetof(SaveData, gap1382) == 0x1382);
+  static_assert(offsetof(SaveData, week_event_reg_131) == 0x12CB);
+  static_assert(offsetof(SaveData, week_event_reg_35) == 0x126B);
+  static_assert(offsetof(SaveData, week_event_reg_87) == 0x129F);
 
   struct CommonDataSub1 {
     int entrance;

--- a/code/include/game/context.h
+++ b/code/include/game/context.h
@@ -86,7 +86,137 @@ namespace game {
     WarpingToStoneTower = 0x25,
   };
 
-  // Incomplete
+  enum class OcarinaMode : u16 {
+    OCARINA_MODE_NONE = 0,
+    OCARINA_MODE_ACTIVE = 1,
+    OCARINA_MODE_WARP = 2,
+    OCARINA_MODE_EVENT = 3,
+    OCARINA_MODE_END = 4,
+    OCARINA_MODE_PLAYED_TIME = 5,
+    OCARINA_MODE_PLAYED_HEALING = 6,
+    OCARINA_MODE_PLAYED_EPONAS = 7,
+    OCARINA_MODE_PLAYED_SOARING = 8,
+    OCARINA_MODE_PLAYED_STORMS = 9,
+    OCARINA_MODE_PLAYED_SUNS = 10,
+    OCARINA_MODE_PLAYED_INVERTED_TIME = 11,
+    OCARINA_MODE_PLAYED_DOUBLE_TIME = 12,
+    OCARINA_MODE_PLAYED_SCARECROW_SPAWN = 13,
+    OCARINA_MODE_E = 14,
+    OCARINA_MODE_F = 15,
+    OCARINA_MODE_10 = 16,
+    OCARINA_MODE_11 = 17,
+    OCARINA_MODE_PROCESS_SOT = 18,
+    OCARINA_MODE_PROCESS_INVERTED_TIME = 19,
+    OCARINA_MODE_14 = 20,
+    OCARINA_MODE_PROCESS_DOUBLE_TIME = 21,
+    OCARINA_MODE_APPLY_SOT = 22,
+    OCARINA_MODE_17 = 23,
+    OCARINA_MODE_APPLY_INV_SOT_FAST = 24,
+    OCARINA_MODE_APPLY_INV_SOT_SLOW = 25,
+    OCARINA_MODE_APPLY_DOUBLE_SOT = 26,
+    OCARINA_MODE_1B = 27,
+    OCARINA_MODE_WARP_TO_GREAT_BAY_COAST = 28,
+    OCARINA_MODE_WARP_TO_ZORA_CAPE = 29,
+    OCARINA_MODE_WARP_TO_SNOWHEAD = 30,
+    OCARINA_MODE_WARP_TO_MOUNTAIN_VILLAGE = 31,
+    OCARINA_MODE_WARP_TO_SOUTH_CLOCK_TOWN = 32,
+    OCARINA_MODE_WARP_TO_MILK_ROAD = 33,
+    OCARINA_MODE_WARP_TO_WOODFALL = 34,
+    OCARINA_MODE_WARP_TO_SOUTHERN_SWAMP = 35,
+    OCARINA_MODE_WARP_TO_IKANA_CANYON = 36,
+    OCARINA_MODE_WARP_TO_STONE_TOWER = 37,
+    OCARINA_MODE_WARP_TO_ENTRANCE = 38,
+    OCARINA_MODE_PROCESS_RESTRICTED_SONG = 39,
+    OCARINA_MODE_28 = 40,
+    OCARINA_MODE_29 = 41,
+    OCARINA_MODE_PLAYED_FULL_EVAN_SONG = 42
+  };
+
+  enum class OcarinaSongActionId : u16 {
+    OCARINA_ACTION_0 = 0,
+    OCARINA_ACTION_FREE_PLAY = 1,
+    OCARINA_ACTION_DEMONSTRATE_SONATA = 2,
+    OCARINA_ACTION_DEMONSTRATE_GORON_LULLABY = 3,
+    OCARINA_ACTION_DEMONSTRATE_NEW_WAVE = 4,
+    OCARINA_ACTION_DEMONSTRATE_ELEGY = 5,
+    OCARINA_ACTION_DEMONSTRATE_OATH = 6,
+    OCARINA_ACTION_DEMONSTRATE_SARIAS = 7,
+    OCARINA_ACTION_DEMONSTRATE_TIME = 8,
+    OCARINA_ACTION_DEMONSTRATE_HEALING = 9,
+    OCARINA_ACTION_DEMONSTRATE_EPONAS = 10,
+    OCARINA_ACTION_DEMONSTRATE_SOARING = 11,
+    OCARINA_ACTION_DEMONSTRATE_STORMS = 12,
+    OCARINA_ACTION_DEMONSTRATE_SUNS = 13,
+    OCARINA_ACTION_DEMONSTRATE_INVERTED_TIME = 14,
+    OCARINA_ACTION_DEMONSTRATE_DOUBLE_TIME = 15,
+    OCARINA_ACTION_DEMONSTRATE_GORON_LULLABY_INTRO = 16,
+    OCARINA_ACTION_11 = 17,
+    OCARINA_ACTION_PROMPT_SONATA = 18,
+    OCARINA_ACTION_PROMPT_GORON_LULLABY = 19,
+    OCARINA_ACTION_PROMPT_NEW_WAVE = 20,
+    OCARINA_ACTION_PROMPT_ELEGY = 21,
+    OCARINA_ACTION_PROMPT_OATH = 22,
+    OCARINA_ACTION_PROMPT_SARIAS = 23,
+    OCARINA_ACTION_PROMPT_TIME = 24,
+    OCARINA_ACTION_PROMPT_HEALING = 25,
+    OCARINA_ACTION_PROMPT_EPONAS = 26,
+    OCARINA_ACTION_PROMPT_SOARING = 27,
+    OCARINA_ACTION_PROMPT_STORMS = 28,
+    OCARINA_ACTION_PROMPT_SUNS = 29,
+    OCARINA_ACTION_PROMPT_INVERTED_TIME = 30,
+    OCARINA_ACTION_PROMPT_DOUBLE_TIME = 31,
+    OCARINA_ACTION_PROMPT_GORON_LULLABY_INTRO = 32,
+    OCARINA_ACTION_21 = 33,
+    OCARINA_ACTION_CHECK_SONATA = 34,
+    OCARINA_ACTION_CHECK_GORON_LULLABY = 35,
+    OCARINA_ACTION_CHECK_NEW_WAVE = 36,
+    OCARINA_ACTION_CHECK_ELEGY = 37,
+    OCARINA_ACTION_CHECK_OATH = 38,
+    OCARINA_ACTION_CHECK_SARIAS = 39,
+    OCARINA_ACTION_CHECK_TIME = 40,
+    OCARINA_ACTION_CHECK_HEALING = 41,
+    OCARINA_ACTION_CHECK_EPONAS = 42,
+    OCARINA_ACTION_CHECK_SOARING = 43,
+    OCARINA_ACTION_CHECK_STORMS = 44,
+    OCARINA_ACTION_CHECK_SUNS = 45,
+    OCARINA_ACTION_CHECK_INVERTED_TIME = 46,
+    OCARINA_ACTION_CHECK_DOUBLE_TIME = 47,
+    OCARINA_ACTION_CHECK_GORON_LULLABY_INTRO = 48,
+    OCARINA_ACTION_CHECK_SCARECROW_SPAWN = 49,
+    OCARINA_ACTION_FREE_PLAY_DONE = 50,
+    OCARINA_ACTION_SCARECROW_LONG_RECORDING = 51,
+    OCARINA_ACTION_SCARECROW_LONG_DEMONSTRATION = 52,
+    OCARINA_ACTION_SCARECROW_SPAWN_RECORDING = 53,
+    OCARINA_ACTION_SCARECROW_SPAWN_DEMONSTRATION = 54,
+    OCARINA_ACTION_37 = 55,
+    OCARINA_ACTION_CHECK_NOTIME = 56,
+    OCARINA_ACTION_CHECK_NOTIME_DONE = 57,
+    OCARINA_ACTION_3A = 58,
+    OCARINA_ACTION_3B = 59,
+    OCARINA_ACTION_3C = 60,
+    OCARINA_ACTION_DEMONSTRATE_EVAN_PART1_FIRST_HALF = 61,
+    OCARINA_ACTION_DEMONSTRATE_EVAN_PART2_FIRST_HALF = 62,
+    OCARINA_ACTION_DEMONSTRATE_EVAN_PART1_SECOND_HALF = 63,
+    OCARINA_ACTION_DEMONSTRATE_EVAN_PART2_SECOND_HALF = 64,
+    OCARINA_ACTION_PROMPT_EVAN_PART1_SECOND_HALF = 65,
+    OCARINA_ACTION_PROMPT_EVAN_PART2_SECOND_HALF = 66,
+    OCARINA_ACTION_PROMPT_WIND_FISH_HUMAN = 67,
+    OCARINA_ACTION_PROMPT_WIND_FISH_GORON = 68,
+    OCARINA_ACTION_PROMPT_WIND_FISH_ZORA = 69,
+    OCARINA_ACTION_PROMPT_WIND_FISH_DEKU = 70,
+    OCARINA_ACTION_TIMED_PROMPT_SONATA = 71,
+    OCARINA_ACTION_TIMED_PROMPT_GORON_LULLABY = 72,
+    OCARINA_ACTION_TIMED_PROMPT_NEW_WAVE = 73,
+    OCARINA_ACTION_TIMED_PROMPT_ELEGY = 74,
+    OCARINA_ACTION_TIMED_PROMPT_OATH = 75,
+    OCARINA_ACTION_TIMED_PROMPT_SARIAS = 76,
+    OCARINA_ACTION_TIMED_PROMPT_TIME = 77,
+    OCARINA_ACTION_TIMED_PROMPT_HEALING = 78,
+    OCARINA_ACTION_TIMED_PROMPT_EPONAS = 79,
+    OCARINA_ACTION_TIMED_PROMPT_SOARING = 80,
+    OCARINA_ACTION_TIMED_PROMPT_STORMS = 81
+  };
+
   enum class OcarinaSong : u16 {
     SonataOfAwakening = 0,
     GoronLullaby = 1,
@@ -98,12 +228,29 @@ namespace game {
     EponaSong = 8,
     SongOfSoaring = 9,
     SongOfStorms = 10,
+    SunsSong = 11,
     InvertedSongOfTime = 12,
     SongOfDoubleTime = 13,
-    ScarecrowSong = 21,
+    GoronLullablyIntro = 14,
+    WindFishHuman = 15,
+    WindFishGoron = 16,
+    WindFishZora = 17,
+    WindFishDeku = 18,
+    EvansSongPart1 = 19,
+    EvansSongPart2 = 20,
+    ZeldasLullaby = 21,
+    ScarecrowSong = 22,
+    TerminaWallSong = 23,
+    SongMax = 24,
 
     InvalidDetecting = 0xfe,
     Invalid = 0xff,
+  };
+
+  struct OcarinaStaff {
+    u8 buttonIndex;
+    u8 song;
+    u8 pos;
   };
 
   struct HudState {
@@ -159,6 +306,59 @@ namespace game {
     u8 field_27C;
   };
   static_assert(sizeof(HudState) == 0x280);
+
+  struct MessageContext {
+    void* notebook_stuff;
+    u8 gap_8024[536];
+    OcarinaStaff* ocarinaStaff_maybe;
+    u16 field_8220;
+    u8 gap_8222[10];
+    int field_822C;
+    u16 field_8230;
+    u16 field_8232;
+    u8 gap_8234[10];
+    u8 hide_hud;
+    u8 field_823F;
+    u8 gap_8240[160];
+    u32 field_82E0;
+    u8 gap_82E4[28];
+    int field_8300;
+    u8 gap_8304[28];
+    int field_8320;
+    u8 gap_8324[28];
+    int state_timer;
+    u8 gap_8343[2];
+    OcarinaMode ocarinaMode;
+    OcarinaSongActionId ocarinaSongActionId;
+    OcarinaSong lastPlayedSong;
+    u8 gap_834A[19];
+    u8 some_ocarina_timer;
+    u16 field_8360;
+    u16 field_8362;
+    OcarinaSong ocarina_song2;
+    OcarinaState ocarina_state;
+    OcarinaState ocarina_state2;
+    OcarinaSong ocarina_song;
+    u16 field_836C;
+    u8 field_836E;
+    u8 field_836F;
+    int field_8370;
+    int field_8374;
+    int field_8378;
+    game::act::Actor* message_actor;
+    u16 field_8380;
+    u16 field_8382;
+    u8 gap_8384[4]; /* ocaEff Spawned here? */
+    int item_cost;
+    int item_cost_two;
+    u8 gap_8390[61];
+    u8 bombers_notebook_event_queue_count;
+    u8 gap_83CE[58];
+  };
+  static_assert(offsetof(MessageContext, field_8232) == 0x232);
+  static_assert(offsetof(MessageContext, ocarinaStaff_maybe) == 0x21c);
+  static_assert(offsetof(MessageContext, gap_8324) == 0x324);
+  static_assert(sizeof(MessageContext) == 0x408);
 
   // Likely incomplete.
   struct GlobalContext : State {
@@ -259,54 +459,11 @@ namespace game {
     u8 gap_3DFE[16898];
     u32 field_8000;
     u8 gap_8004[28];
-    void* notebook_stuff;
-    u8 gap_8024[536];
-    void* ocarinaData;
-    u16 field_8220;
-    u8 gap_8222[10];
-    int field_822C;
-    u8 gap_8230[2];
-    u16 field_8232;
-    u8 gap_8234[10];
-    u8 hide_hud;
-    u8 field_823F;
-    u8 gap_8240[160];
-    u32 field_8300;
-    u8 gap_8304[28];
-    int field_8320;
-    u8 gap_8324[59];
-    u8 some_ocarina_timer;
-    u16 field_8360;
-    u16 field_8362;
-    OcarinaSong ocarina_song2;
-    OcarinaState ocarina_state;
-    OcarinaState ocarina_state2;
-    OcarinaSong ocarina_song;
-    u16 field_836C;
-    char field_836E;
-    char field_836F;
-    int field_8370;
-    int field_8374;
-    int field_8378;
-    act::Actor* messageActor;
-    u16 field_8380;
-    u16 field_8382;
-    u8 gap_8384[4];  // ocaeffSpawned in here.
-    int item_cost;
-    int another_item_cost_maybe;
-    u8 gap_8390[62];
-    u16 field_83CE;  // frame counter for notebook?
-    u8 field_83CD;
-    u8 gap_83D0[10];
-    u32 field_83DE;  // Checks during song
-    u16 field_83E0;
-    u16 field_83E2;  // Stored message ID for after notebook collection. Mainly used for fishing
-                     // pass/PoH/rupee text.
-    u8 gap_83E0[68];
+    MessageContext msg_context;
     HudState hud_state;
     u8 gap_86A8[4];
     u16 field_86AC;
-    __attribute__((aligned(4))) u8 gap_86B0[272];
+    u8 gap_86B0[272];
     u32 field_87C0;
     u8 gap_87C4[59];
     u8 field_87FF;
@@ -460,15 +617,9 @@ namespace game {
   static_assert(offsetof(GlobalContext, pause_flags) == 0xAAC);
   static_assert(offsetof(GlobalContext, elegy_statues) == 0x2394);
   static_assert(offsetof(GlobalContext, field_C000) == 0xc000);
-  static_assert(offsetof(GlobalContext, ocarina_state) == 0x8366);
-  static_assert(offsetof(GlobalContext, ocarina_song) == 0x836A);
-  static_assert(offsetof(GlobalContext, hide_hud) == 0x825E);
-  static_assert(offsetof(GlobalContext, field_836E) == 0x836E);
-  static_assert(offsetof(GlobalContext, gap_8390) == 0x8390);
   static_assert(offsetof(GlobalContext, field_C4C8) == 0xC4C8);
   static_assert(offsetof(GlobalContext, gap_AC6C) == 0xAC6C);
-  static_assert(offsetof(GlobalContext, field_83CE) == 0x83CE);
-  static_assert(offsetof(GlobalContext, gap_8384) == 0x8384);
+  static_assert(offsetof(GlobalContext, msg_context) == 0x8020);
   static_assert(offsetof(GlobalContext, gap_404) == 0x0404);
   static_assert(offsetof(GlobalContext, object_context) == 0x9438);
   static_assert(sizeof(GlobalContext) == 0x11030);

--- a/code/include/game/items.h
+++ b/code/include/game/items.h
@@ -148,7 +148,7 @@ namespace game {
 
     InvertedSongOfTime = 0x71,
     SongOfDoubleTime = 0x72,
-    X73 = 0x73,
+    GoronLullabyIntro = 0x73,
 
     BossKey = 0x74,
     Compass = 0x75,

--- a/code/include/game/weekeventreg.h
+++ b/code/include/game/weekeventreg.h
@@ -145,7 +145,6 @@ namespace game {
     BitField<3, 1, u8> WEEKEVENTREG_09_08;
     BitField<4, 1, u8> WEEKEVENTREG_09_10;
 
-
     BitField<5, 1, u8> WEEKEVENTREG_09_20;
     BitField<6, 1, u8> WEEKEVENTREG_09_40;
     BitField<7, 1, u8> WEEKEVENTREG_09_80;
@@ -174,7 +173,7 @@ namespace game {
     BitField<4, 1, u8> WEEKEVENTREG_11_10;
     BitField<5, 1, u8> WEEKEVENTREG_11_20;
     BitField<6, 1, u8> WEEKEVENTREG_11_40;
-    BitField<7, 1, u8> WEEKEVENTREG_11_80; // XXX: Possible collected fairy from clocktown.
+    BitField<7, 1, u8> WEEKEVENTREG_11_80;  // XXX: Possible collected fairy from clocktown.
   };
 
   union WeekEventReg12 {
@@ -187,7 +186,7 @@ namespace game {
     BitField<2, 1, u8> WEEKEVENTREG_12_04;
     BitField<3, 1, u8> WEEKEVENTREG_SAVED_KOUME;
     BitField<4, 1, u8> WEEKEVENTREG_RECEIVED_KOTAKE_BOTTLE;
-    BitField<5, 1, u8> WEEKEVENTREG_12_20; // CT Guard Allows you through without talking.
+    BitField<5, 1, u8> WEEKEVENTREG_12_20;  // CT Guard Allows you through without talking.
     BitField<6, 1, u8> WEEKEVENTREG_12_40;
     BitField<7, 1, u8> WEEKEVENTREG_12_80;
   };
@@ -470,7 +469,7 @@ namespace game {
     // Woodfall Temple Frog Returned
     BitField<6, 1, u8> WEEKEVENTREG_32_40;
     // Great Bay Temple Frog Returned
-    BitField<7, 1, u8> WEEKEVENTREG_32_80;  
+    BitField<7, 1, u8> WEEKEVENTREG_32_80;
   };
 
   union WeekEventReg33 {
@@ -479,7 +478,7 @@ namespace game {
     // Southern Swamp Frog Returned
     BitField<0, 1, u8> WEEKEVENTREG_33_01;
     // Laundry Pool Frog Returned
-    BitField<1, 1, u8> WEEKEVENTREG_33_02;  
+    BitField<1, 1, u8> WEEKEVENTREG_33_02;
     BitField<2, 1, u8> WEEKEVENTREG_BOUGHT_CURIOSITY_SHOP_SPECIAL_ITEM;
     BitField<3, 1, u8> WEEKEVENTREG_RECOVERED_STOLEN_BOMB_BAG;
     BitField<4, 1, u8> WEEKEVENTREG_33_10;
@@ -676,11 +675,10 @@ namespace game {
     BitField<6, 1, u8> WEEKEVENTREG_48_40;
     BitField<7, 1, u8> WEEKEVENTREG_48_80;
   };
-  
 
   union WeekEventReg49 {
     u8 raw;
-    
+
     BitField<0, 1, u8> WEEKEVENTREG_49_01;
     BitField<1, 1, u8> WEEKEVENTREG_49_02;
     BitField<2, 1, u8> WEEKEVENTREG_49_04;
@@ -1238,7 +1236,6 @@ namespace game {
     BitField<1, 1, u8> WEEKEVENTREG_92_02;
     BitField<2, 1, u8> WEEKEVENTREG_92_04;
 
-
     BitField<3, 1, u8> WEEKEVENTREG_92_08;
     BitField<4, 1, u8> WEEKEVENTREG_92_10;
     BitField<5, 1, u8> WEEKEVENTREG_92_20;
@@ -1693,24 +1690,24 @@ namespace game {
 
   union WeekEventReg130 {
     u8 raw;
-    BitField<0, 1, u8> WEEKEVENTREG_OWL_STATUE_CUTSCENE;
+    BitField<0, 1, u8> WEEKEVENTREG_130_01;
     BitField<1, 1, u8> WEEKEVENTREG_130_02;
     BitField<2, 1, u8> WEEKEVENTREG_130_04;
-    BitField<3, 1, u8> WEEKEVENTREG_SKIP_MAP_TUTORIAL_BY_TINGLE;
-    BitField<4, 1, u8> WEEKEVENTREG_DEKU_THRONE_ROOM_CAMERA_PAN;
-    BitField<5, 1, u8> WEEKEVENTREG_TATL_MOON_TEAR_DIALOGUE;
+    BitField<3, 1, u8> WEEKEVENTREG_130_08;
+    BitField<4, 1, u8> WEEKEVENTREG_130_10;
+    BitField<5, 1, u8> WEEKEVENTREG_130_20;
     BitField<6, 1, u8> WEEKEVENTREG_130_40;
     BitField<7, 1, u8> WEEKEVENTREG_130_80;
   };
 
   union WeekEventReg131 {
     u8 raw;
-    BitField<0, 1, u8> WEEKEVENTREG_131_01;
+    BitField<0, 1, u8> WEEKEVENTREG_OWL_STATUE_CUTSCENE;
     BitField<1, 1, u8> WEEKEVENTREG_131_02;
     BitField<2, 1, u8> WEEKEVENTREG_131_04;
-    BitField<3, 1, u8> WEEKEVENTREG_131_08;
-    BitField<4, 1, u8> WEEKEVENTREG_131_10;
-    BitField<5, 1, u8> WEEKEVENTREG_131_20;
+    BitField<3, 1, u8> WEEKEVENTREG_SKIP_MAP_TUTORIAL_BY_TINGLE;
+    BitField<4, 1, u8> WEEKEVENTREG_DEKU_THRONE_ROOM_CAMERA_PAN;
+    BitField<5, 1, u8> WEEKEVENTREG_TATL_MOON_TEAR_DIALOGUE;
     BitField<6, 1, u8> WEEKEVENTREG_131_40;
     BitField<7, 1, u8> WEEKEVENTREG_131_80;
   };
@@ -1725,7 +1722,6 @@ namespace game {
     BitField<5, 1, u8> WEEKEVENTREG_SKIP_SNOWHEAD_PORTAL_CUTSCENE;
     BitField<6, 1, u8> WEEKEVENTREGSKIP_GREAT_BAY_PORTAL_CUTSCENE;
     BitField<7, 1, u8> WEEKEVENTREG_SKIP_STT_PORTAL_CUTSCENE;
-    
   };
 
   union WeekEventReg133 {
@@ -1811,6 +1807,6 @@ namespace game {
     BitField<6, 1, u8> WEEKEVENTREG_139_40;
     BitField<7, 1, u8> WEEKEVENTREG_139_80;
   };
-}
+}  // namespace game
 
 #endif  // _GAME_WEEK_EVENT_REG_H

--- a/code/include/game/weekeventreg.h
+++ b/code/include/game/weekeventreg.h
@@ -1,0 +1,1816 @@
+/**
+ * @file weekeventreg.h
+ * @author phlexplexico (https://github.com/phlexplexico/)
+ * @brief
+ * @date 2025-11-12
+ *
+ */
+#ifndef _GAME_WEEK_EVENT_REG_H
+#define _GAME_WEEK_EVENT_REG_H
+
+namespace game {
+  union WeekEventReg00 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_00_01;
+    BitField<1, 1, u8> WEEKEVENTREG_ENTERED_TERMINA_FIELD;
+    BitField<2, 1, u8> WEEKEVENTREG_ENTERED_IKANA_GRAVEYARD;
+    BitField<3, 1, u8> WEEKEVENTREG_ENTERED_ROMANI_RANCH;
+    BitField<4, 2, u8> WEEKEVENTREG_ENTERED_GORMAN_TRACK;
+    BitField<5, 1, u8> WEEKEVENTREG_ENTERED_MOUNTAIN_VILLAGE_WINTER;
+    BitField<6, 1, u8> WEEKEVENTREG_ENTERED_GORON_SHRINE;
+    BitField<7, 1, u8> WEEKEVENTREG_ENTERED_SNOWHEAD;
+  };
+
+  union WeekEventReg01 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE;
+    BitField<1, 1, u8> WEEKEVENTREG_ENTERED_SNOWHEAD_TEMPLE;
+    BitField<2, 1, u8> WEEKEVENTREG_ENTERED_GREAT_BAY_TEMPLE;
+    BitField<3, 1, u8> WEEKEVENTREG_ENTERED_STONE_TOWER_TEMPLE;
+    BitField<4, 1, u8> WEEKEVENTREG_COMPLETED_WOODFALL_TEMPLE;
+    BitField<5, 1, u8> WEEKEVENTREG_COMPLETED_SNOWHEAD_TEMPLE;
+    BitField<6, 1, u8> WEEKEVENTREG_COMPLETED_GREAT_BAY_TEMPLE;
+    BitField<7, 1, u8> WEEKEVENTREG_COMPLETED_STONE_TOWER_TEMPLE;
+  };
+
+  // Attached to the scene but unused. Entrance cutscene is instead triggered by `ACTOR_OBJ_DEMO`
+  union WeekEventReg02 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_ENTERED_IKANA_CASTLE;
+    BitField<1, 1, u8> WEEKEVENTREG_ENTERED_STONE_TOWER;
+    BitField<2, 1, u8> WEEKEVENTREG_ENTERED_STONE_TOWER_INVERTED;
+    BitField<3, 1, u8> WEEKEVENTREG_ENTERED_EAST_CLOCK_TOWN;
+    BitField<4, 1, u8> WEEKEVENTREG_ENTERED_WEST_CLOCK_TOWN;
+    BitField<5, 1, u8> WEEKEVENTREG_ENTERED_NORTH_CLOCK_TOWN;
+    BitField<6, 1, u8> WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE;
+    BitField<7, 1, u8> WEEKEVENTREG_ENTERED_SNOWHEAD_TEMPLE;
+  };
+
+  // Attached to the scene but unused. Entrance cutscene is instead triggered by `ACTOR_OBJ_DEMO`
+  union WeekEventReg03 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_ENTERED_PIRATES_FORTRESS_EXTERIOR;
+    BitField<1, 1, u8> WEEKEVENTREG_ENTERED_STONE_TOWER_TEMPLE;
+    BitField<2, 1, u8> WEEKEVENTREG_ENTERED_STONE_TOWER_TEMPLE_INVERTED;
+    // Unused as no cutscene is attached to this script
+    BitField<3, 1, u8> WEEKEVENTREG_ENTERED_THE_MOON;
+    BitField<4, 1, u8> WEEKEVENTREG_ENTERED_MOON_DEKU_TRIAL;
+    BitField<5, 1, u8> WEEKEVENTREG_ENTERED_MOON_GORON_TRIAL;
+    BitField<6, 1, u8> WEEKEVENTREG_ENTERED_MOON_ZORA_TRIAL;
+    BitField<7, 1, u8> WEEKEVENTREG_03_80;
+  };
+
+  union WeekEventReg04 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_04_01;
+    BitField<1, 1, u8> WEEKEVENTREG_04_02;
+    BitField<2, 1, u8> WEEKEVENTREG_04_04;
+    BitField<3, 1, u8> WEEKEVENTREG_04_08;
+    BitField<4, 1, u8> WEEKEVENTREG_04_10;
+    BitField<5, 1, u8> WEEKEVENTREG_04_20;
+    BitField<6, 1, u8> WEEKEVENTREG_04_40;
+    BitField<7, 1, u8> WEEKEVENTREG_04_80;
+  };
+
+  union WeekEventReg05 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_05_01;
+    BitField<1, 1, u8> WEEKEVENTREG_05_02;
+    BitField<2, 1, u8> WEEKEVENTREG_05_04;
+    BitField<3, 1, u8> WEEKEVENTREG_05_08;
+    BitField<4, 1, u8> WEEKEVENTREG_05_10;
+    BitField<5, 1, u8> WEEKEVENTREG_05_20;
+    BitField<6, 1, u8> WEEKEVENTREG_05_40;
+    BitField<7, 1, u8> WEEKEVENTREG_05_80;
+  };
+
+  union WeekEventReg06 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_06_01;
+    BitField<1, 1, u8> WEEKEVENTREG_06_02;
+    BitField<2, 1, u8> WEEKEVENTREG_06_04;
+    BitField<3, 1, u8> WEEKEVENTREG_06_08;
+    BitField<4, 1, u8> WEEKEVENTREG_06_10;
+    BitField<5, 1, u8> WEEKEVENTREG_06_20;
+    BitField<6, 1, u8> WEEKEVENTREG_06_40;
+    BitField<7, 1, u8> WEEKEVENTREG_06_80;
+  };
+
+  union WeekEventReg07 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_07_01;
+    BitField<1, 1, u8> WEEKEVENTREG_07_02;
+    BitField<2, 1, u8> WEEKEVENTREG_07_04;
+    BitField<3, 1, u8> WEEKEVENTREG_07_08;
+    BitField<4, 1, u8> WEEKEVENTREG_07_10;
+    BitField<5, 1, u8> WEEKEVENTREG_07_20;
+    BitField<6, 1, u8> WEEKEVENTREG_07_40;
+    BitField<7, 1, u8> WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE_PRISON;
+  };
+
+  union WeekEventReg08 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_08_01;
+    BitField<1, 1, u8> WEEKEVENTREG_08_02;
+    BitField<2, 1, u8> WEEKEVENTREG_08_04;
+    BitField<3, 1, u8> WEEKEVENTREG_08_08;
+    BitField<4, 1, u8> WEEKEVENTREG_08_10;
+    BitField<5, 1, u8> WEEKEVENTREG_RECEIVED_DOGGY_RACETRACK_HEART_PIECE;
+    // This is set under three circumstances:
+    // 1. The player watches the cutscene of the Clock Tower opening.
+    // 2. The player sees the Clock Tower opening outside of a cutscene. After the first cycle, this
+    //    can be seen in Termina Field or in North, East, or West Clock Town.
+    // 3. The player enters Termina Field or North, South, East, or West Clock Town any time after
+    //    midnight on the Final Day.
+    // Thus, it is possible for the player to be in the final six hours and still have this unset; all
+    // the player needs to do is avoid certain areas.
+    BitField<6, 1, u8> WEEKEVENTREG_CLOCK_TOWER_OPENED;
+    BitField<7, 1, u8> WEEKEVENTREG_08_80;
+  };
+
+  union WeekEventReg09 {
+    u8 raw;
+    // This 5 flags are managed in a special way by EnElfgrp
+    BitField<0, 1, u8> WEEKEVENTREG_09_01;
+    BitField<1, 1, u8> WEEKEVENTREG_09_02;
+    BitField<2, 1, u8> WEEKEVENTREG_09_04;
+    BitField<3, 1, u8> WEEKEVENTREG_09_08;
+    BitField<4, 1, u8> WEEKEVENTREG_09_10;
+
+
+    BitField<5, 1, u8> WEEKEVENTREG_09_20;
+    BitField<6, 1, u8> WEEKEVENTREG_09_40;
+    BitField<7, 1, u8> WEEKEVENTREG_09_80;
+  };
+
+  union WeekEventReg10 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_TALKED_TINGLE;
+    BitField<1, 1, u8> WEEKEVENTREG_10_02;
+    BitField<2, 1, u8> WEEKEVENTREG_10_04;
+    BitField<3, 1, u8> WEEKEVENTREG_RECEIVED_BANK_WALLET_UPGRADE;
+    BitField<4, 1, u8> WEEKEVENTREG_10_10;
+    BitField<5, 1, u8> WEEKEVENTREG_10_20;
+    BitField<6, 1, u8> WEEKEVENTREG_10_40;
+    BitField<7, 1, u8> WEEKEVENTREG_10_80;
+  };
+
+  union WeekEventReg11 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_11_01;
+    BitField<1, 1, u8> WEEKEVENTREG_11_02;
+    BitField<2, 1, u8> WEEKEVENTREG_11_04;
+    BitField<3, 1, u8> WEEKEVENTREG_11_08;
+    BitField<4, 1, u8> WEEKEVENTREG_11_10;
+    BitField<5, 1, u8> WEEKEVENTREG_11_20;
+    BitField<6, 1, u8> WEEKEVENTREG_11_40;
+    BitField<7, 1, u8> WEEKEVENTREG_11_80; // XXX: Possible collected fairy from clocktown.
+  };
+
+  union WeekEventReg12 {
+    u8 raw;
+
+    // woodfall temple wood flower opened
+    BitField<0, 1, u8> WEEKEVENTREG_12_01;
+
+    BitField<1, 1, u8> WEEKEVENTREG_12_02;
+    BitField<2, 1, u8> WEEKEVENTREG_12_04;
+    BitField<3, 1, u8> WEEKEVENTREG_SAVED_KOUME;
+    BitField<4, 1, u8> WEEKEVENTREG_RECEIVED_KOTAKE_BOTTLE;
+    BitField<5, 1, u8> WEEKEVENTREG_12_20; // CT Guard Allows you through without talking.
+    BitField<6, 1, u8> WEEKEVENTREG_12_40;
+    BitField<7, 1, u8> WEEKEVENTREG_12_80;
+  };
+
+  union WeekEventReg13 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_13_01;
+    BitField<1, 1, u8> WEEKEVENTREG_13_02;
+    BitField<2, 1, u8> WEEKEVENTREG_13_04;
+    BitField<3, 1, u8> WEEKEVENTREG_13_08;
+    BitField<4, 1, u8> WEEKEVENTREG_13_10;
+
+    // This flag marks that the player has finished the Oceanside Spider House and has exited.
+    // Used to identify if EnSth should be moved deeper into the house.
+    // This does NOT flag:
+    //   A) that the player has completed the house (Inventory_GetSkullTokenCount(play->sceneId))
+    //   B) that the player has collected a reward (WEEKEVENTREG_OCEANSIDE_SPIDER_HOUSE_COLLECTED_REWARD)
+    //   C) that the player has collected the wallet (WEEKEVENTREG_RECEIVED_OCEANSIDE_WALLET_UPGRADE)
+    BitField<5, 1, u8> WEEKEVENTREG_OCEANSIDE_SPIDER_HOUSE_BUYER_MOVED_IN;
+    BitField<6, 1, u8> WEEKEVENTREG_RECEIVED_OCEANSIDE_WALLET_UPGRADE;
+    BitField<7, 1, u8> WEEKEVENTREG_OCEANSIDE_SPIDER_HOUSE_COLLECTED_REWARD;
+  };
+
+  union WeekEventReg14 {
+    u8 raw;
+
+    // PlayedMilkMinigame
+    // Attempted Cremia Cart Ride
+    BitField<0, 1, u8> WEEKEVENTREG_14_01;
+
+    BitField<1, 1, u8> WEEKEVENTREG_14_02;
+    BitField<2, 1, u8> WEEKEVENTREG_14_04;
+    BitField<3, 1, u8> WEEKEVENTREG_DRANK_CHATEAU_ROMANI;
+    BitField<4, 1, u8> WEEKEVENTREG_WON_DEKU_PLAYGROUND_DAY_1;
+    BitField<5, 1, u8> WEEKEVENTREG_WON_DEKU_PLAYGROUND_DAY_2;
+    BitField<6, 1, u8> WEEKEVENTREG_WON_DEKU_PLAYGROUND_DAY_3;
+    BitField<7, 1, u8> WEEKEVENTREG_RECEIVED_DEKU_PLAYGROUND_HEART_PIECE;
+  };
+
+  union WeekEventReg15 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_15_01;
+    BitField<1, 1, u8> WEEKEVENTREG_15_02;
+    BitField<2, 1, u8> WEEKEVENTREG_15_04;
+    BitField<3, 1, u8> WEEKEVENTREG_15_08;
+    BitField<4, 1, u8> WEEKEVENTREG_15_10;
+    BitField<5, 1, u8> WEEKEVENTREG_15_20;
+    BitField<6, 1, u8> WEEKEVENTREG_15_40;
+    BitField<7, 1, u8> WEEKEVENTREG_15_80;
+  };
+
+  union WeekEventReg16 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_16_01;
+    BitField<1, 1, u8> WEEKEVENTREG_16_02;
+    BitField<2, 1, u8> WEEKEVENTREG_16_04;
+    BitField<3, 1, u8> WEEKEVENTREG_16_08;
+    BitField<4, 1, u8> WEEKEVENTREG_TALKED_KOUME_INJURED;
+    BitField<5, 1, u8> WEEKEVENTREG_16_20;
+    BitField<6, 1, u8> WEEKEVENTREG_16_40;
+    BitField<7, 1, u8> WEEKEVENTREG_16_80;
+  };
+
+  union WeekEventReg17 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_TALKED_KOUME_KIOSK_EMPTY;
+    BitField<1, 1, u8> WEEKEVENTREG_17_02;
+    BitField<2, 1, u8> WEEKEVENTREG_17_04;
+    BitField<3, 1, u8> WEEKEVENTREG_17_08;
+    BitField<4, 1, u8> WEEKEVENTREG_17_10;
+    BitField<5, 1, u8> WEEKEVENTREG_17_20;
+    BitField<6, 1, u8> WEEKEVENTREG_17_40;
+    BitField<7, 1, u8> WEEKEVENTREG_RECEIVED_LAND_TITLE_DEED;
+  };
+
+  union WeekEventReg18 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_18_01;
+    BitField<1, 1, u8> WEEKEVENTREG_18_02;
+    BitField<2, 1, u8> WEEKEVENTREG_TALKED_CURIOSITY_SHOP_MAN_AS_GORON;
+    BitField<3, 1, u8> WEEKEVENTREG_TALKED_CURIOSITY_SHOP_MAN_AS_ZORA;
+    BitField<4, 1, u8> WEEKEVENTREG_TALKED_CURIOSITY_SHOP_MAN_AS_DEKU;
+    BitField<5, 1, u8> WEEKEVENTREG_18_20;
+    BitField<6, 1, u8> WEEKEVENTREG_18_40;
+
+    // Player has Powder Keg purchasing privileges.
+    BitField<7, 1, u8> WEEKEVENTREG_HAS_POWDERKEG_PRIVILEGES;
+  };
+
+  union WeekEventReg19 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_19_01;
+    BitField<1, 1, u8> WEEKEVENTREG_19_02;
+    BitField<2, 1, u8> WEEKEVENTREG_19_04;
+    BitField<3, 1, u8> WEEKEVENTREG_19_08;
+    BitField<4, 1, u8> WEEKEVENTREG_19_10;
+    BitField<5, 1, u8> WEEKEVENTREG_19_20;
+    BitField<6, 1, u8> WEEKEVENTREG_19_40;
+    BitField<7, 1, u8> WEEKEVENTREG_19_80;
+  };
+
+  union WeekEventReg20 {
+    u8 raw;
+
+    // woodfall temple purification cutscene watched
+    BitField<0, 1, u8> WEEKEVENTREG_CLEARED_WOODFALL_TEMPLE;
+
+    BitField<1, 1, u8> WEEKEVENTREG_20_02;
+    BitField<2, 1, u8> WEEKEVENTREG_20_04;
+    BitField<3, 1, u8> WEEKEVENTREG_20_08;
+    BitField<4, 1, u8> WEEKEVENTREG_20_10;
+    BitField<5, 1, u8> WEEKEVENTREG_20_20;
+    BitField<6, 1, u8> WEEKEVENTREG_20_40;
+    BitField<7, 1, u8> WEEKEVENTREG_20_80;
+  };
+
+  union WeekEventReg21 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_21_01;
+    BitField<1, 1, u8> WEEKEVENTREG_21_02;
+
+    // Player has spoken to Goron Graveyard's gravemaker while in Goron form.
+    BitField<2, 1, u8> WEEKEVENTREG_TALKED_GORON_GRAVEMAKER_AS_GORON;
+    // Player has spoken to formerly frozen Goron outside Goron Graveyard.
+    BitField<3, 1, u8> WEEKEVENTREG_TALKED_THAWED_GRAVEYARD_GORON;
+    BitField<4, 1, u8> WEEKEVENTREG_21_10;
+    // Player talked with Romani before the alien invasion and agreed to help her
+    BitField<5, 1, u8> WEEKEVENTREG_PROMISED_TO_HELP_WITH_ALIENS;
+    BitField<6, 1, u8> WEEKEVENTREG_21_40;
+    BitField<7, 1, u8> WEEKEVENTREG_21_80;
+  };
+
+  union WeekEventReg22 {
+    BitField<0, 1, u8> WEEKEVENTREG_22_01;
+    BitField<1, 1, u8> WEEKEVENTREG_22_02;
+    BitField<2, 1, u8> WEEKEVENTREG_22_04;
+    BitField<3, 1, u8> WEEKEVENTREG_22_08;
+    BitField<4, 1, u8> WEEKEVENTREG_22_10;
+    BitField<5, 1, u8> WEEKEVENTREG_22_20;
+    BitField<6, 1, u8> WEEKEVENTREG_22_40;
+    BitField<7, 1, u8> WEEKEVENTREG_RECEIVED_HONEY_AND_DARLING_HEART_PIECE;
+  };
+
+  union WeekEventReg23 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_23_01;
+    BitField<1, 1, u8> WEEKEVENTREG_RECEIVED_GREAT_SPIN_ATTACK;
+    BitField<2, 1, u8> WEEKEVENTREG_23_04;
+    BitField<3, 1, u8> WEEKEVENTREG_23_08;
+    BitField<4, 1, u8> WEEKEVENTREG_23_10;
+    BitField<5, 1, u8> WEEKEVENTREG_23_20;
+    BitField<6, 1, u8> WEEKEVENTREG_23_40;
+    BitField<7, 1, u8> WEEKEVENTREG_RECEIVED_BEAVER_RACE_BOTTLE;
+  };
+
+  union WeekEventReg24 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_24_01;
+    BitField<1, 1, u8> WEEKEVENTREG_24_02;
+    BitField<2, 1, u8> WEEKEVENTREG_24_04;
+    BitField<3, 1, u8> WEEKEVENTREG_24_08;
+    // The player has already talked as a Goron at least once to Goron elder
+    BitField<4, 1, u8> WEEKEVENTREG_24_10;
+    // The player has already talked as a non-Goron at least once
+    BitField<5, 1, u8> WEEKEVENTREG_24_20;
+    BitField<6, 1, u8> WEEKEVENTREG_24_40;
+    // The player has talked to the Goron Child at least once
+    BitField<7, 1, u8> WEEKEVENTREG_24_80;
+  };
+
+  union WeekEventReg25 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_RECEIVED_BEAVER_BROS_HEART_PIECE;
+    BitField<1, 1, u8> WEEKEVENTREG_25_02;
+    BitField<2, 1, u8> WEEKEVENTREG_25_04;
+    BitField<3, 1, u8> WEEKEVENTREG_BREMAN_MASK_USED;
+    BitField<4, 1, u8> WEEKEVENTREG_25_10;
+    BitField<5, 1, u8> WEEKEVENTREG_25_20;
+    BitField<6, 1, u8> WEEKEVENTREG_25_40;
+    BitField<7, 1, u8> WEEKEVENTREG_25_80;
+  };
+
+  union WeekEventReg26 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_26_01;
+    BitField<1, 1, u8> WEEKEVENTREG_26_02;
+    BitField<2, 1, u8> WEEKEVENTREG_26_04;
+    BitField<3, 1, u8> WEEKEVENTREG_26_08;
+    BitField<4, 1, u8> WEEKEVENTREG_26_10;
+    BitField<5, 1, u8> WEEKEVENTREG_26_20;
+    BitField<6, 1, u8> WEEKEVENTREG_26_40;
+    BitField<7, 1, u8> WEEKEVENTREG_26_80;
+  };
+
+  union WeekEventReg27 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_27_01;
+    BitField<1, 1, u8> WEEKEVENTREG_DEPOSITED_LETTER_TO_KAFEI_SOUTH_UPPER_CLOCKTOWN;
+    BitField<2, 1, u8> WEEKEVENTREG_DEPOSITED_LETTER_TO_KAFEI_NORTH_CLOCKTOWN;
+    BitField<3, 1, u8> WEEKEVENTREG_DEPOSITED_LETTER_TO_KAFEI_EAST_UPPER_CLOCKTOWN;
+    BitField<4, 1, u8> WEEKEVENTREG_DEPOSITED_LETTER_TO_KAFEI_EAST_LOWER_CLOCKTOWN;
+    BitField<5, 1, u8> WEEKEVENTREG_DEPOSITED_LETTER_TO_KAFEI_SOUTH_LOWER_CLOCKTOWN;
+    BitField<6, 1, u8> WEEKEVENTREG_27_40;
+    BitField<7, 1, u8> WEEKEVENTREG_27_80;
+  };
+
+  union WeekEventReg28 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_28_01;
+    BitField<1, 1, u8> WEEKEVENTREG_28_02;
+    BitField<2, 1, u8> WEEKEVENTREG_28_04;
+    BitField<3, 1, u8> WEEKEVENTREG_28_08;
+    BitField<4, 1, u8> WEEKEVENTREG_28_10;
+    BitField<5, 1, u8> WEEKEVENTREG_28_20;
+    BitField<6, 1, u8> WEEKEVENTREG_28_40;
+    BitField<7, 1, u8> WEEKEVENTREG_28_80;
+  };
+
+  union WeekEventReg29 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_29_01;
+    BitField<1, 1, u8> WEEKEVENTREG_29_02;
+    BitField<2, 1, u8> WEEKEVENTREG_29_04;
+    BitField<3, 1, u8> WEEKEVENTREG_29_08;
+    BitField<4, 1, u8> WEEKEVENTREG_29_10;
+    BitField<5, 1, u8> WEEKEVENTREG_29_20;
+    BitField<6, 1, u8> WEEKEVENTREG_29_40;
+    BitField<7, 1, u8> WEEKEVENTREG_29_80;
+  };
+
+  union WeekEventReg30 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_30_01;
+    BitField<1, 1, u8> WEEKEVENTREG_30_02;
+    BitField<2, 1, u8> WEEKEVENTREG_30_04;
+    BitField<3, 1, u8> WEEKEVENTREG_30_08;
+    BitField<4, 1, u8> WEEKEVENTREG_WORN_DEKU_MASK_ONCE;
+    BitField<5, 1, u8> WEEKEVENTREG_WORN_GORON_MASK_ONCE;
+    BitField<6, 1, u8> WEEKEVENTREG_WORN_ZORA_MASK_ONCE;
+    BitField<7, 1, u8> WEEKEVENTREG_WORN_FIERCE_DEITY_MASK_ONCE;
+  };
+
+  union WeekEventReg31 {
+    u8 raw;
+    // Unconfirmed: "Tatl's Second Cycle Text?"
+    BitField<2, 1, u8> WEEKEVENTREG_TATL_NOT_FINISHED_MOUNTAIN_TEXT;
+    BitField<3, 1, u8> WEEKEVENTREG_TATL_NOT_FINISHED_OCEAN_TEXT;
+    BitField<4, 1, u8> WEEKEVENTREG_TATL_GO_SOUTH_TEXT;
+    BitField<5, 1, u8> WEEKEVENTREG_31_20;
+    // Cremia asked the player to accompany her to town
+    BitField<6, 1, u8> WEEKEVENTREG_31_40;
+    // Player is playing the Milk Run
+    BitField<7, 1, u8> WEEKEVENTREG_31_80;
+  };
+
+  union WeekEventReg32 {
+    u8 raw;
+
+    BitField<0, 1, u8> WEEKEVENTREG_RECEIVED_SEAHORSE_HEART_PIECE;
+    BitField<1, 1, u8> WEEKEVENTREG_RECEIVED_SWAMP_SHOOTING_GALLERY_HEART_PIECE;
+    BitField<2, 1, u8> WEEKEVENTREG_RECEIVED_TOWN_SHOOTING_GALLERY_HEART_PIECE;
+    BitField<3, 1, u8> WEEKEVENTREG_32_08;
+    BitField<4, 1, u8> WEEKEVENTREG_32_10;
+    BitField<5, 1, u8> WEEKEVENTREG_32_20;
+    // Woodfall Temple Frog Returned
+    BitField<6, 1, u8> WEEKEVENTREG_32_40;
+    // Great Bay Temple Frog Returned
+    BitField<7, 1, u8> WEEKEVENTREG_32_80;  
+  };
+
+  union WeekEventReg33 {
+    u8 raw;
+
+    // Southern Swamp Frog Returned
+    BitField<0, 1, u8> WEEKEVENTREG_33_01;
+    // Laundry Pool Frog Returned
+    BitField<1, 1, u8> WEEKEVENTREG_33_02;  
+    BitField<2, 1, u8> WEEKEVENTREG_BOUGHT_CURIOSITY_SHOP_SPECIAL_ITEM;
+    BitField<3, 1, u8> WEEKEVENTREG_RECOVERED_STOLEN_BOMB_BAG;
+    BitField<4, 1, u8> WEEKEVENTREG_33_10;
+    BitField<5, 1, u8> WEEKEVENTREG_33_20;
+    BitField<6, 1, u8> WEEKEVENTREG_33_40;
+    // Mountain village unfrozen
+    BitField<7, 1, u8> WEEKEVENTREG_CLEARED_SNOWHEAD_TEMPLE;
+  };
+
+  union WeekEventReg34 {
+    u8 raw;
+    // Spoken to FROG_YELLOW
+    BitField<0, 1, u8> WEEKEVENTREG_34_01;
+    BitField<1, 1, u8> WEEKEVENTREG_34_02;
+    BitField<2, 1, u8> WEEKEVENTREG_34_04;
+    BitField<3, 1, u8> WEEKEVENTREG_TALKED_SWAMP_SPIDER_HOUSE_MAN;
+    BitField<4, 1, u8> WEEKEVENTREG_34_10;
+    BitField<5, 1, u8> WEEKEVENTREG_34_20;
+    BitField<6, 1, u8> WEEKEVENTREG_RECEIVED_MASK_OF_TRUTH;
+    // Cremia did Milk Run alone. Player didn't interact or didn't accept the ride
+    BitField<7, 1, u8> WEEKEVENTREG_34_80;
+  };
+
+  union WeekEventReg35 {
+    u8 raw;
+    // Bought each possible map from Tingle
+    BitField<0, 1, u8> WEEKEVENTREG_TINGLE_MAP_BOUGHT_CLOCK_TOWN;
+    BitField<1, 1, u8> WEEKEVENTREG_TINGLE_MAP_BOUGHT_WOODFALL;
+    BitField<2, 1, u8> WEEKEVENTREG_TINGLE_MAP_BOUGHT_SNOWHEAD;
+    BitField<3, 1, u8> WEEKEVENTREG_TINGLE_MAP_BOUGHT_ROMANI_RANCH;
+    BitField<4, 1, u8> WEEKEVENTREG_TINGLE_MAP_BOUGHT_GREAT_BAY;
+    BitField<5, 1, u8> WEEKEVENTREG_TINGLE_MAP_BOUGHT_STONE_TOWER;
+    BitField<6, 1, u8> WEEKEVENTREG_35_40;
+    // Obtained Heart Piece from Five Frogs of the Frog Choir
+    BitField<7, 1, u8> WEEKEVENTREG_RECEIVED_FROG_CHOIR_HEART_PIECE;
+  };
+
+  union WeekEventReg36 {
+    u8 raw;
+    // Player has spoken to certain shrine gorons in the winter
+    BitField<0, 1, u8> WEEKEVENTREG_36_01;
+    BitField<1, 1, u8> WEEKEVENTREG_36_02;
+    BitField<2, 1, u8> WEEKEVENTREG_36_04;
+    BitField<3, 1, u8> WEEKEVENTREG_36_08;
+    BitField<4, 1, u8> WEEKEVENTREG_36_10;
+    BitField<5, 1, u8> WEEKEVENTREG_36_20;
+    BitField<6, 1, u8> WEEKEVENTREG_36_40;
+    BitField<7, 1, u8> WEEKEVENTREG_36_80;
+  };
+
+  union WeekEventReg37 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_37_01;
+    BitField<1, 1, u8> WEEKEVENTREG_37_02;
+    BitField<2, 1, u8> WEEKEVENTREG_37_04;
+    BitField<3, 1, u8> WEEKEVENTREG_37_08;
+    // Sets to 1 if the rock sirloin has spawned.
+    BitField<4, 1, u8> WEEKEVENTREG_37_10;
+    BitField<5, 1, u8> WEEKEVENTREG_37_20;
+    BitField<6, 1, u8> WEEKEVENTREG_37_40;
+    BitField<7, 1, u8> WEEKEVENTREG_37_80;
+  };
+
+  union WeekEventReg38 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_38_01;
+    BitField<1, 1, u8> WEEKEVENTREG_38_02;
+    BitField<2, 1, u8> WEEKEVENTREG_38_04;
+    BitField<3, 1, u8> WEEKEVENTREG_38_08;
+    BitField<4, 1, u8> WEEKEVENTREG_38_10;
+    BitField<5, 1, u8> WEEKEVENTREG_38_20;
+    BitField<6, 1, u8> WEEKEVENTREG_38_40;
+    BitField<7, 1, u8> WEEKEVENTREG_38_80;
+  };
+
+  union WeekEventReg39 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_39_01;
+    BitField<1, 1, u8> WEEKEVENTREG_39_02;
+    BitField<2, 1, u8> WEEKEVENTREG_39_04;
+    BitField<3, 1, u8> WEEKEVENTREG_39_08;
+    BitField<4, 1, u8> WEEKEVENTREG_39_10;
+    BitField<5, 1, u8> WEEKEVENTREG_RECEIVED_EVAN_HEART_PIECE;
+    BitField<6, 1, u8> WEEKEVENTREG_39_40;
+    BitField<7, 1, u8> WEEKEVENTREG_39_80;
+  };
+
+  union WeekEventReg40 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_40_01;
+    BitField<1, 1, u8> WEEKEVENTREG_40_02;
+    BitField<2, 1, u8> WEEKEVENTREG_40_04;
+    BitField<3, 1, u8> WEEKEVENTREG_40_08;
+    BitField<4, 1, u8> WEEKEVENTREG_40_10;
+    BitField<5, 1, u8> WEEKEVENTREG_40_20;
+    BitField<6, 1, u8> WEEKEVENTREG_40_40;
+    BitField<7, 1, u8> WEEKEVENTREG_40_80;
+  };
+
+  union WeekEventReg41 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_41_01;
+    BitField<1, 1, u8> WEEKEVENTREG_41_02;
+    BitField<2, 1, u8> WEEKEVENTREG_41_04;
+    BitField<3, 1, u8> WEEKEVENTREG_RECEIVED_GORON_RACE_BOTTLE;
+    BitField<4, 1, u8> WEEKEVENTREG_41_10;
+    BitField<5, 1, u8> WEEKEVENTREG_41_20;
+    BitField<6, 1, u8> WEEKEVENTREG_41_40;
+    BitField<7, 1, u8> WEEKEVENTREG_41_80;
+  };
+  // Used for storing the text ID offsets for the dogs in the Doggy Racetrack (56 entries)
+  // The number of weekEventRegs used needs to be kept in sync with RACEDOG_COUNT in z_en_aob_01.h
+  // PACK_WEEKEVENTREG_FLAG(42, 0x01) to PACK_WEEKEVENTREG_FLAG(48, 0x80)
+  union WeekEventReg42 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_42_01;
+    BitField<1, 1, u8> WEEKEVENTREG_42_02;
+    BitField<2, 1, u8> WEEKEVENTREG_42_04;
+    BitField<3, 1, u8> WEEKEVENTREG_42_08;
+    BitField<4, 1, u8> WEEKEVENTREG_42_10;
+    BitField<5, 1, u8> WEEKEVENTREG_42_20;
+    BitField<6, 1, u8> WEEKEVENTREG_42_40;
+    BitField<7, 1, u8> WEEKEVENTREG_42_80;
+  };
+
+  union WeekEventReg43 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_43_01;
+    BitField<1, 1, u8> WEEKEVENTREG_43_02;
+    BitField<2, 1, u8> WEEKEVENTREG_43_04;
+    BitField<3, 1, u8> WEEKEVENTREG_43_08;
+    BitField<4, 1, u8> WEEKEVENTREG_43_10;
+    BitField<5, 1, u8> WEEKEVENTREG_43_20;
+    BitField<6, 1, u8> WEEKEVENTREG_43_40;
+    BitField<7, 1, u8> WEEKEVENTREG_43_80;
+  };
+
+  union WeekEventReg44 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_44_01;
+    BitField<1, 1, u8> WEEKEVENTREG_44_02;
+    BitField<2, 1, u8> WEEKEVENTREG_44_04;
+    BitField<3, 1, u8> WEEKEVENTREG_44_08;
+    BitField<4, 1, u8> WEEKEVENTREG_44_10;
+    BitField<5, 1, u8> WEEKEVENTREG_44_20;
+    BitField<6, 1, u8> WEEKEVENTREG_44_40;
+    BitField<7, 1, u8> WEEKEVENTREG_44_80;
+  };
+
+  union WeekEventReg45 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_45_01;
+    BitField<1, 1, u8> WEEKEVENTREG_45_02;
+    BitField<2, 1, u8> WEEKEVENTREG_45_04;
+    BitField<3, 1, u8> WEEKEVENTREG_45_08;
+    BitField<4, 1, u8> WEEKEVENTREG_45_10;
+    BitField<5, 1, u8> WEEKEVENTREG_45_20;
+    BitField<6, 1, u8> WEEKEVENTREG_45_40;
+    BitField<7, 1, u8> WEEKEVENTREG_45_80;
+  };
+
+  union WeekEventReg46 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_46_01;
+    BitField<1, 1, u8> WEEKEVENTREG_46_02;
+    BitField<2, 1, u8> WEEKEVENTREG_46_04;
+    BitField<3, 1, u8> WEEKEVENTREG_46_08;
+    BitField<4, 1, u8> WEEKEVENTREG_46_10;
+    BitField<5, 1, u8> WEEKEVENTREG_46_20;
+    BitField<6, 1, u8> WEEKEVENTREG_46_40;
+    BitField<7, 1, u8> WEEKEVENTREG_46_80;
+  };
+
+  union WeekEventReg47 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_47_01;
+    BitField<1, 1, u8> WEEKEVENTREG_47_02;
+    BitField<2, 1, u8> WEEKEVENTREG_47_04;
+    BitField<3, 1, u8> WEEKEVENTREG_47_08;
+    BitField<4, 1, u8> WEEKEVENTREG_47_10;
+    BitField<5, 1, u8> WEEKEVENTREG_47_20;
+    BitField<6, 1, u8> WEEKEVENTREG_47_40;
+    BitField<7, 1, u8> WEEKEVENTREG_47_80;
+  };
+
+  union WeekEventReg48 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_48_01;
+    BitField<1, 1, u8> WEEKEVENTREG_48_02;
+    BitField<2, 1, u8> WEEKEVENTREG_48_04;
+    BitField<3, 1, u8> WEEKEVENTREG_48_08;
+    BitField<4, 1, u8> WEEKEVENTREG_48_10;
+    BitField<5, 1, u8> WEEKEVENTREG_48_20;
+    BitField<6, 1, u8> WEEKEVENTREG_48_40;
+    BitField<7, 1, u8> WEEKEVENTREG_48_80;
+  };
+  
+
+  union WeekEventReg49 {
+    u8 raw;
+    
+    BitField<0, 1, u8> WEEKEVENTREG_49_01;
+    BitField<1, 1, u8> WEEKEVENTREG_49_02;
+    BitField<2, 1, u8> WEEKEVENTREG_49_04;
+    BitField<3, 1, u8> WEEKEVENTREG_49_08;
+    BitField<4, 1, u8> WEEKEVENTREG_49_10;
+    BitField<5, 1, u8> WEEKEVENTREG_49_20;
+    BitField<6, 1, u8> WEEKEVENTREG_49_40;
+    BitField<7, 1, u8> WEEKEVENTREG_49_80;
+  };
+
+  union WeekEventReg50 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_50_01;
+    BitField<1, 1, u8> WEEKEVENTREG_50_02;
+    BitField<2, 1, u8> WEEKEVENTREG_50_04;
+    BitField<3, 1, u8> WEEKEVENTREG_PROMISED_MIDNIGHT_MEETING;
+    BitField<4, 1, u8> WEEKEVENTREG_50_10;
+    BitField<5, 1, u8> WEEKEVENTREG_HAD_MIDNIGHT_MEETING;
+    BitField<6, 1, u8> WEEKEVENTREG_50_40;
+    BitField<7, 1, u8> WEEKEVENTREG_RECEIVED_PENDANT_OF_MEMORIES;
+  };
+
+  union WeekEventReg51 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_DELIVERED_PENDANT_OF_MEMORIES;
+    BitField<1, 1, u8> WEEKEVENTREG_51_02;
+    BitField<2, 1, u8> WEEKEVENTREG_51_04;
+    BitField<3, 1, u8> WEEKEVENTREG_51_08;
+    BitField<4, 1, u8> WEEKEVENTREG_51_10;
+    BitField<5, 1, u8> WEEKEVENTREG_ESCAPED_SAKONS_HIDEOUT;
+    // Set by Kafei
+    BitField<6, 1, u8> WEEKEVENTREG_COUPLES_MASK_CUTSCENE_FINISHED;
+    BitField<7, 1, u8> WEEKEVENTREG_51_80;
+  };
+
+  union WeekEventReg52 {
+    u8 raw;
+    // Protected Cremia
+    BitField<0, 1, u8> WEEKEVENTREG_ESCORTED_CREMIA;
+    // Lose Milk Run minigame
+    BitField<1, 1, u8> WEEKEVENTREG_52_02;
+    BitField<2, 1, u8> WEEKEVENTREG_52_04;
+    BitField<3, 1, u8> WEEKEVENTREG_52_08;
+    BitField<4, 1, u8> WEEKEVENTREG_52_10;
+    BitField<5, 1, u8> WEEKEVENTREG_CLEARED_STONE_TOWER_TEMPLE;
+    BitField<6, 1, u8> WEEKEVENTREG_52_40;
+    BitField<7, 1, u8> WEEKEVENTREG_52_80;
+  };
+
+  union WeekEventReg53 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_53_01;
+    BitField<1, 1, u8> WEEKEVENTREG_RECEIVED_BUSINESS_SCRUB_HEART_PIECE;
+    BitField<2, 1, u8> WEEKEVENTREG_53_04;
+    BitField<3, 1, u8> WEEKEVENTREG_GAVE_KOTAKE_MUSHROOM;
+    BitField<4, 1, u8> WEEKEVENTREG_RECEIVED_FREE_BLUE_POTION;
+    BitField<5, 1, u8> WEEKEVENTREG_53_20;
+    BitField<6, 1, u8> WEEKEVENTREG_53_40;
+    BitField<7, 1, u8> WEEKEVENTREG_53_80;
+  };
+
+  union WeekEventReg54 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_54_01;
+    BitField<1, 1, u8> WEEKEVENTREG_54_02;
+    BitField<2, 1, u8> WEEKEVENTREG_54_04;
+    BitField<3, 1, u8> WEEKEVENTREG_54_08;
+    BitField<4, 1, u8> WEEKEVENTREG_TALKED_ROMANI_ON_NIGHT_1;
+    BitField<5, 1, u8> WEEKEVENTREG_54_20;
+    BitField<6, 1, u8> WEEKEVENTREG_RECEIVED_SPIRIT_HOUSE_HEART_PIECE;
+    BitField<7, 1, u8> WEEKEVENTREG_54_80;
+  };
+
+  union WeekEventReg55 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_55_01;
+    // Unconfirmed: "Link the Goron Claims His Reservation: 4:30 PM"
+    BitField<1, 1, u8> WEEKEVENTREG_55_02;
+    BitField<2, 1, u8> WEEKEVENTREG_TALKED_PART_TIMER_AS_GORON;
+    BitField<3, 1, u8> WEEKEVENTREG_TALKED_PART_TIMER_AS_ZORA;
+    BitField<4, 1, u8> WEEKEVENTREG_TALKED_PART_TIMER_AS_DEKU;
+    BitField<5, 1, u8> WEEKEVENTREG_TALKED_ANJU_IN_LAUNDRY_POOL;
+    BitField<6, 1, u8> WEEKEVENTREG_55_40;
+    // Gyorg has been defeated
+    BitField<7, 1, u8> WEEKEVENTREG_CLEARED_GREAT_BAY_TEMPLE;
+  };
+
+  union WeekEventReg56 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_56_01;
+    BitField<1, 1, u8> WEEKEVENTREG_RECEIVED_MARINE_RESEARCH_LAB_FISH_HEART_PIECE;
+    BitField<2, 1, u8> WEEKEVENTREG_56_04;
+    BitField<3, 1, u8> WEEKEVENTREG_56_08;
+    BitField<4, 1, u8> WEEKEVENTREG_56_10;
+    BitField<5, 1, u8> WEEKEVENTREG_56_20;
+    BitField<6, 1, u8> WEEKEVENTREG_56_40;
+    BitField<7, 1, u8> WEEKEVENTREG_56_80;
+  };
+
+  union WeekEventReg57 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_57_01;
+    BitField<1, 1, u8> WEEKEVENTREG_57_02;
+    BitField<2, 1, u8> WEEKEVENTREG_57_04;
+    BitField<3, 1, u8> WEEKEVENTREG_57_08;
+    BitField<4, 1, u8> WEEKEVENTREG_TALKED_ZORA_SHOPKEEPER_AS_HUMAN;
+    BitField<5, 1, u8> WEEKEVENTREG_TALKED_ZORA_SHOPKEEPER_AS_DEKU;
+    BitField<6, 1, u8> WEEKEVENTREG_TALKED_ZORA_SHOPKEEPER_AS_GORON;
+    BitField<7, 1, u8> WEEKEVENTREG_TALKED_ZORA_SHOPKEEPER_AS_ZORA;
+  };
+
+  union WeekEventReg58 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_58_01;
+    BitField<1, 1, u8> WEEKEVENTREG_58_02;
+    BitField<2, 1, u8> WEEKEVENTREG_TALKED_GORON_SHOPKEEPER_AS_NON_GORON;
+    BitField<3, 1, u8> WEEKEVENTREG_TALKED_GORON_SHOPKEEPER_AS_GORON;
+    BitField<4, 1, u8> WEEKEVENTREG_TALKED_GORON_SHOPKEEPER_SPRING_AS_NON_GORON;
+    BitField<5, 1, u8> WEEKEVENTREG_TALKED_GORON_SHOPKEEPER_SPRING_AS_GORON;
+    BitField<6, 1, u8> WEEKEVENTREG_58_40;
+    BitField<7, 1, u8> WEEKEVENTREG_58_80;
+  };
+
+  union WeekEventReg59 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_59_01;
+    BitField<1, 1, u8> WEEKEVENTREG_59_02;
+    // Unconfirmed: "Entered South Clock Town"
+    BitField<2, 1, u8> WEEKEVENTREG_59_04;
+    BitField<3, 1, u8> WEEKEVENTREG_RECEIVED_BANK_HEART_PIECE;
+    BitField<4, 1, u8> WEEKEVENTREG_RECEIVED_SWAMP_SHOOTING_GALLERY_QUIVER_UPGRADE;
+    BitField<5, 1, u8> WEEKEVENTREG_RECEIVED_TOWN_SHOOTING_GALLERY_QUIVER_UPGRADE;
+    BitField<6, 1, u8> WEEKEVENTREG_59_40;
+    BitField<7, 1, u8> WEEKEVENTREG_59_80;
+  };
+
+  union WeekEventReg60 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_60_01;
+    BitField<1, 1, u8> WEEKEVENTREG_60_02;
+    BitField<2, 1, u8> WEEKEVENTREG_60_04;
+    BitField<3, 1, u8> WEEKEVENTREG_ATTENDED_MAYOR_MEETING;
+    BitField<4, 1, u8> WEEKEVENTREG_RECEIVED_MAYOR_HEART_PIECE;
+    BitField<5, 1, u8> WEEKEVENTREG_60_20;
+    BitField<6, 1, u8> WEEKEVENTREG_TALKED_MAYOR_NIGHT_3;
+    BitField<7, 1, u8> WEEKEVENTREG_60_80;
+  };
+
+  union WeekEventReg61 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_61_01;
+    BitField<1, 1, u8> WEEKEVENTREG_61_02;
+    BitField<2, 1, u8> WEEKEVENTREG_61_04;
+    BitField<3, 1, u8> WEEKEVENTREG_61_08;
+    BitField<4, 1, u8> WEEKEVENTREG_61_10;
+    BitField<5, 1, u8> WEEKEVENTREG_61_20;
+    BitField<6, 1, u8> WEEKEVENTREG_61_40;
+    BitField<7, 1, u8> WEEKEVENTREG_61_80;
+  };
+
+  union WeekEventReg62 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_62_01;
+    BitField<1, 1, u8> WEEKEVENTREG_62_02;
+    BitField<2, 1, u8> WEEKEVENTREG_62_04;
+    BitField<3, 1, u8> WEEKEVENTREG_62_08;
+    BitField<4, 1, u8> WEEKEVENTREG_62_10;
+    BitField<5, 1, u8> WEEKEVENTREG_62_20;
+    BitField<6, 1, u8> WEEKEVENTREG_62_40;
+    BitField<7, 1, u8> WEEKEVENTREG_62_80;
+  };
+
+  union WeekEventReg63 {
+    u8 raw;
+    // See `EnTimeTag_KickOut_WaitForTime` and `EnTimeTag_KickOut_WaitForTrigger`
+    BitField<0, 1, u8> WEEKEVENTREG_KICKOUT_WAIT;
+    // See `EnTimeTag_KickOut_WaitForTime` and `EnTimeTag_KickOut_WaitForTrigger`
+    BitField<1, 1, u8> WEEKEVENTREG_KICKOUT_TIME_PASSED;
+    BitField<2, 1, u8> WEEKEVENTREG_63_04;
+    BitField<3, 1, u8> WEEKEVENTREG_63_08;
+    BitField<4, 1, u8> WEEKEVENTREG_63_10;
+    BitField<5, 1, u8> WEEKEVENTREG_RECEIVED_SWORDSMANS_SCHOOL_HEART_PIECE;
+    BitField<6, 1, u8> WEEKEVENTREG_63_40;
+    // Showed Couple's Mask at meeting
+    BitField<7, 1, u8> WEEKEVENTREG_RESOLVED_MAYOR_MEETING;
+  };
+
+  union WeekEventReg64 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_64_01;
+    BitField<1, 1, u8> WEEKEVENTREG_64_02;
+    BitField<2, 1, u8> WEEKEVENTREG_64_04;
+    //  0 - Zora, LOW_BIT - Deku, HIGH_BIT - Goron, LOW_BIT & HIGH_BIT - Human
+    BitField<3, 1, u8> WEEKEVENTREG_TINGLE_RECOGNIZED_PLAYER_FORM_LOW_BIT;
+    BitField<4, 1, u8> WEEKEVENTREG_TINGLE_RECOGNIZED_PLAYER_FORM_HIGH_BIT;
+    BitField<5, 1, u8> WEEKEVENTREG_64_20;
+    BitField<6, 1, u8> WEEKEVENTREG_64_40;
+    BitField<7, 1, u8> WEEKEVENTREG_TALKED_DOGGY_RACETRACK_OWNER_DAY_1;
+  };
+
+  union WeekEventReg65 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_TALKED_DOGGY_RACETRACK_OWNER_NIGHT_1;
+    BitField<1, 1, u8> WEEKEVENTREG_TALKED_DOGGY_RACETRACK_OWNER_DAY_2;
+    BitField<2, 1, u8> WEEKEVENTREG_TALKED_DOGGY_RACETRACK_OWNER_NIGHT_2;
+    BitField<3, 1, u8> WEEKEVENTREG_TALKED_DOGGY_RACETRACK_OWNER_DAY_3;
+    BitField<4, 1, u8> WEEKEVENTREG_TALKED_DOGGY_RACETRACK_OWNER_NIGHT_3;
+    BitField<5, 1, u8> WEEKEVENTREG_65_20;
+    BitField<6, 1, u8> WEEKEVENTREG_65_40;
+    BitField<7, 1, u8> WEEKEVENTREG_65_80;
+  };
+
+  union WeekEventReg66 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_66_01;
+    BitField<1, 1, u8> WEEKEVENTREG_66_02;
+    BitField<2, 1, u8> WEEKEVENTREG_66_04;
+    BitField<3, 1, u8> WEEKEVENTREG_66_08;
+    BitField<4, 1, u8> WEEKEVENTREG_66_10;
+    BitField<5, 1, u8> WEEKEVENTREG_66_20;
+    BitField<6, 1, u8> WEEKEVENTREG_66_40;
+    BitField<7, 1, u8> WEEKEVENTREG_66_80;
+  };
+
+  union WeekEventReg67 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_67_01;
+    BitField<1, 1, u8> WEEKEVENTREG_67_02;
+    BitField<2, 1, u8> WEEKEVENTREG_67_04;
+    BitField<3, 1, u8> WEEKEVENTREG_67_08;
+    BitField<4, 1, u8> WEEKEVENTREG_67_10;
+    BitField<5, 1, u8> WEEKEVENTREG_67_20;
+    BitField<6, 1, u8> WEEKEVENTREG_67_40;
+    BitField<7, 1, u8> WEEKEVENTREG_67_80;
+  };
+
+  union WeekEventReg68 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_68_01;
+    BitField<1, 1, u8> WEEKEVENTREG_68_02;
+    BitField<2, 1, u8> WEEKEVENTREG_68_04;
+    BitField<3, 1, u8> WEEKEVENTREG_68_08;
+    BitField<4, 1, u8> WEEKEVENTREG_68_10;
+    BitField<5, 1, u8> WEEKEVENTREG_68_20;
+    BitField<6, 1, u8> WEEKEVENTREG_68_40;
+    BitField<7, 1, u8> WEEKEVENTREG_68_80;
+  };
+
+  union WeekEventReg69 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_69_01;
+    BitField<1, 1, u8> WEEKEVENTREG_69_02;
+    BitField<2, 1, u8> WEEKEVENTREG_69_04;
+    BitField<3, 1, u8> WEEKEVENTREG_69_08;
+    BitField<4, 1, u8> WEEKEVENTREG_69_10;
+    BitField<5, 1, u8> WEEKEVENTREG_69_20;
+    BitField<6, 1, u8> WEEKEVENTREG_69_40;
+    BitField<7, 1, u8> WEEKEVENTREG_69_80;
+  };
+
+  union WeekEventReg70 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_70_01;
+    BitField<1, 1, u8> WEEKEVENTREG_70_02;
+    BitField<2, 1, u8> WEEKEVENTREG_70_04;
+    BitField<3, 1, u8> WEEKEVENTREG_70_08;
+    BitField<4, 1, u8> WEEKEVENTREG_70_10;
+    BitField<5, 1, u8> WEEKEVENTREG_70_20;
+    BitField<6, 1, u8> WEEKEVENTREG_70_40;
+    BitField<7, 1, u8> WEEKEVENTREG_70_80;
+  };
+
+  union WeekEventReg71 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_71_01;
+    BitField<1, 1, u8> WEEKEVENTREG_71_02;
+    BitField<2, 1, u8> WEEKEVENTREG_71_04;
+    BitField<3, 1, u8> WEEKEVENTREG_71_08;
+    BitField<4, 1, u8> WEEKEVENTREG_71_10;
+    BitField<5, 1, u8> WEEKEVENTREG_71_20;
+    BitField<6, 1, u8> WEEKEVENTREG_71_40;
+    BitField<7, 1, u8> WEEKEVENTREG_71_80;
+  };
+
+  union WeekEventReg72 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_72_01;
+    BitField<1, 1, u8> WEEKEVENTREG_72_02;
+    BitField<2, 1, u8> WEEKEVENTREG_72_04;
+    BitField<3, 1, u8> WEEKEVENTREG_72_08;
+    BitField<4, 1, u8> WEEKEVENTREG_72_10;
+    BitField<5, 1, u8> WEEKEVENTREG_72_20;
+    BitField<6, 1, u8> WEEKEVENTREG_72_40;
+    BitField<7, 1, u8> WEEKEVENTREG_72_80;
+  };
+
+  union WeekEventReg73 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_73_01;
+    BitField<1, 1, u8> WEEKEVENTREG_73_02;
+    BitField<2, 1, u8> WEEKEVENTREG_73_04;
+    BitField<3, 1, u8> WEEKEVENTREG_73_08;
+    // Unconfirmed: "Bombers Hide & Seek started on Day 1?"
+    BitField<4, 1, u8> WEEKEVENTREG_73_10;
+    BitField<5, 1, u8> WEEKEVENTREG_73_20;
+    BitField<6, 1, u8> WEEKEVENTREG_73_40;
+    BitField<7, 1, u8> WEEKEVENTREG_73_80;
+  };
+
+  union WeekEventReg74 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_74_01;
+    BitField<1, 1, u8> WEEKEVENTREG_74_02;
+    BitField<2, 1, u8> WEEKEVENTREG_74_04;
+    BitField<3, 1, u8> WEEKEVENTREG_74_08;
+    BitField<4, 1, u8> WEEKEVENTREG_74_10;
+    BitField<5, 1, u8> WEEKEVENTREG_74_20;
+    BitField<6, 1, u8> WEEKEVENTREG_74_40;
+    BitField<7, 1, u8> WEEKEVENTREG_74_80;
+  };
+
+  union WeekEventReg75 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_75_01;
+    BitField<1, 1, u8> WEEKEVENTREG_75_02;
+    BitField<2, 1, u8> WEEKEVENTREG_75_04;
+    BitField<3, 1, u8> WEEKEVENTREG_75_08;
+    BitField<4, 1, u8> WEEKEVENTREG_RECEIVED_ROOM_KEY;
+    BitField<5, 1, u8> WEEKEVENTREG_75_20;
+    BitField<6, 1, u8> WEEKEVENTREG_75_40;
+    BitField<7, 1, u8> WEEKEVENTREG_RECEIVED_ROSA_SISTERS_HEART_PIECE;
+  };
+
+  union WeekEventReg76 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_76_01;
+    BitField<1, 1, u8> WEEKEVENTREG_76_02;
+    BitField<2, 1, u8> WEEKEVENTREG_76_04;
+    BitField<3, 1, u8> WEEKEVENTREG_76_08;
+    BitField<4, 1, u8> WEEKEVENTREG_76_10;
+    BitField<5, 1, u8> WEEKEVENTREG_76_20;
+    BitField<6, 1, u8> WEEKEVENTREG_76_40;
+    BitField<7, 1, u8> WEEKEVENTREG_76_80;
+  };
+
+  union WeekEventReg77 {
+    // Grotto stone bitflags may exist here.
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_RECEIVED_POSTMAN_COUNTING_GAME_HEART_PIECE;
+    BitField<1, 1, u8> WEEKEVENTREG_77_02;
+    BitField<2, 1, u8> WEEKEVENTREG_77_04;
+    BitField<3, 1, u8> WEEKEVENTREG_77_08;
+    BitField<4, 1, u8> WEEKEVENTREG_77_10;
+    BitField<5, 1, u8> WEEKEVENTREG_77_20;
+    BitField<6, 1, u8> WEEKEVENTREG_77_40;
+    // The player has heard the Goron Shrine cheer as a Goron at least once.
+    BitField<7, 1, u8> WEEKEVENTREG_77_80;
+  };
+
+  union WeekEventReg78 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_78_01;
+    BitField<1, 1, u8> WEEKEVENTREG_78_02;
+    BitField<2, 1, u8> WEEKEVENTREG_78_04;
+    BitField<3, 1, u8> WEEKEVENTREG_78_08;
+    BitField<4, 1, u8> WEEKEVENTREG_78_10;
+    BitField<5, 1, u8> WEEKEVENTREG_78_20;
+    BitField<6, 1, u8> WEEKEVENTREG_78_40;
+    BitField<7, 1, u8> WEEKEVENTREG_78_80;
+  };
+
+  union WeekEventReg79 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_79_01;
+    BitField<1, 1, u8> WEEKEVENTREG_79_02;
+    BitField<2, 1, u8> WEEKEVENTREG_79_04;
+    // removes sacrecrow from shop.
+    BitField<3, 1, u8> WEEKEVENTREG_79_08;
+    BitField<4, 1, u8> WEEKEVENTREG_79_10;
+    BitField<5, 1, u8> WEEKEVENTREG_79_20;
+    BitField<6, 1, u8> WEEKEVENTREG_SAKON_DEAD;
+    BitField<7, 1, u8> WEEKEVENTREG_RECEIVED_KEATON_HEART_PIECE;
+  };
+
+  union WeekEventReg80 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_80_01;
+    BitField<1, 1, u8> WEEKEVENTREG_80_02;
+    BitField<2, 1, u8> WEEKEVENTREG_80_04;
+    // Aveil has spotted Player
+    BitField<3, 1, u8> WEEKEVENTREG_80_08;
+    BitField<4, 1, u8> WEEKEVENTREG_RECEIVED_PRIORITY_MAIL;
+    BitField<5, 1, u8> WEEKEVENTREG_80_20;
+    BitField<6, 1, u8> WEEKEVENTREG_80_40;
+    BitField<7, 1, u8> WEEKEVENTREG_80_80;
+  };
+
+  union WeekEventReg81 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_81_01;
+    BitField<1, 1, u8> WEEKEVENTREG_81_02;
+    BitField<2, 1, u8> WEEKEVENTREG_81_04;
+    BitField<3, 1, u8> WEEKEVENTREG_81_08;
+    BitField<4, 1, u8> WEEKEVENTREG_81_10;
+    BitField<5, 1, u8> WEEKEVENTREG_81_20;
+    BitField<6, 1, u8> WEEKEVENTREG_81_40;
+    BitField<7, 1, u8> WEEKEVENTREG_81_80;
+  };
+
+  union WeekEventReg82 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_82_01;
+    BitField<1, 1, u8> WEEKEVENTREG_82_02;
+    // check if already healed Kamaro the Dancing Ghost
+    BitField<2, 1, u8> WEEKEVENTREG_82_04;
+    // Related to Swordsman's log minigame
+    BitField<3, 1, u8> WEEKEVENTREG_82_08;
+    BitField<4, 1, u8> WEEKEVENTREG_RECEIVED_FISHERMANS_JUMPING_GAME_HEART_PIECE;
+    BitField<5, 1, u8> WEEKEVENTREG_82_20;
+    BitField<6, 1, u8> WEEKEVENTREG_82_40;
+    BitField<7, 1, u8> WEEKEVENTREG_82_80;
+  };
+
+  union WeekEventReg83 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_83_01;
+    // Knocked the Gerudo beehive down
+    BitField<1, 1, u8> WEEKEVENTREG_83_02;
+    BitField<2, 1, u8> WEEKEVENTREG_83_04;
+    // Used for loginc in CanUseItem.
+    BitField<3, 1, u8> WEEKEVENTREG_83_08;
+    BitField<4, 1, u8> WEEKEVENTREG_83_10;
+    BitField<5, 1, u8> WEEKEVENTREG_83_20;
+    BitField<6, 1, u8> WEEKEVENTREG_83_40;
+    BitField<7, 1, u8> WEEKEVENTREG_83_80;
+  };
+
+  union WeekEventReg84 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_84_01;
+    BitField<1, 1, u8> WEEKEVENTREG_84_02;
+    BitField<2, 1, u8> WEEKEVENTREG_84_04;
+    BitField<3, 1, u8> WEEKEVENTREG_84_08;
+    BitField<4, 1, u8> WEEKEVENTREG_84_10;
+    // Also related to moon child
+    BitField<5, 1, u8> WEEKEVENTREG_84_20;
+    BitField<6, 1, u8> WEEKEVENTREG_RECEIVED_RED_POTION_FOR_KOUME;
+    BitField<7, 1, u8> WEEKEVENTREG_84_80;
+  };
+
+  union WeekEventReg85 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_85_01;
+    // Unconfirmed: "Bombers Hide & Seek in Progress"
+    BitField<1, 1, u8> WEEKEVENTREG_85_02;
+    BitField<2, 1, u8> WEEKEVENTREG_85_04;
+    // but is unable to do so since all bottles are full.
+    BitField<3, 1, u8> WEEKEVENTREG_FAILED_RECEIVED_RED_POTION_FOR_KOUME_SHOP;
+    BitField<4, 1, u8> WEEKEVENTREG_FAILED_RECEIVED_RED_POTION_FOR_KOUME_WOODS;
+    BitField<5, 1, u8> WEEKEVENTREG_85_20;
+    BitField<6, 1, u8> WEEKEVENTREG_85_40;
+    // Unconfirmed: "Postman showing priority mail to Madame"
+    BitField<7, 1, u8> WEEKEVENTREG_85_80;
+  };
+
+  union WeekEventReg86 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_86_01;
+    BitField<1, 1, u8> WEEKEVENTREG_86_02;
+    BitField<2, 1, u8> WEEKEVENTREG_86_04;
+    BitField<3, 1, u8> WEEKEVENTREG_LISTENED_ANJU_POSTMAN_CONVERSATION;
+    BitField<4, 1, u8> WEEKEVENTREG_86_10;
+    BitField<5, 1, u8> WEEKEVENTREG_86_20;
+    BitField<6, 1, u8> WEEKEVENTREG_86_40;
+    BitField<7, 1, u8> WEEKEVENTREG_86_80;
+  };
+
+  union WeekEventReg87 {
+    u8 raw;
+    // Currently talking to a cow using the voice recognition unit
+    BitField<0, 1, u8> WEEKEVENTREG_TALKING_TO_COW_WITH_VOICE;
+    // Set by Anju
+    BitField<1, 1, u8> WEEKEVENTREG_COUPLES_MASK_CUTSCENE_STARTED;
+    BitField<2, 1, u8> WEEKEVENTREG_87_04;
+    BitField<3, 1, u8> WEEKEVENTREG_87_08;
+    BitField<4, 1, u8> WEEKEVENTREG_TATL_GO_NORTH_DIALOGUE_SPOKEN;
+    BitField<5, 1, u8> WEEKEVENTREG_TATL_GO_WEST_DIALOGUE_SPOKEN;
+    BitField<6, 1, u8> WEEKEVENTREG_TATL_GO_EAST_DIALOGUE_SPOKEN;
+    BitField<7, 1, u8> WEEKEVENTREG_TATL_GO_TO_MOON_DIALOGUE_SPOKEN;
+  };
+
+  union WeekEventReg88 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_88_01;
+    BitField<1, 1, u8> WEEKEVENTREG_88_02;
+    BitField<2, 1, u8> WEEKEVENTREG_88_04;
+    BitField<3, 1, u8> WEEKEVENTREG_88_08;
+    BitField<4, 1, u8> WEEKEVENTREG_MIKAU_PUSHED_TO_SHORE;
+    BitField<5, 1, u8> WEEKEVENTREG_88_20;
+    // Goron shrine Gatekeeper has opened shrine.
+    BitField<6, 1, u8> WEEKEVENTREG_GATEKEEPER_OPENED_GORON_SHRINE;
+    // Goron shrine Gatekeeper has opened shrine for player in Human form.
+    BitField<7, 1, u8> WEEKEVENTREG_GATEKEEPER_OPENED_GORON_SHRINE_FOR_HUMAN;
+  };
+
+  union WeekEventReg89 {
+    u8 raw;
+    // Goron shrine Gatekeeper has opened shrine for player in Deku form.
+    BitField<0, 1, u8> WEEKEVENTREG_GATEKEEPER_OPENED_GORON_SHRINE_FOR_DEKU;
+    // Goron shrine Gatekeeper has opened shrine for player in Zora form.
+    BitField<1, 1, u8> WEEKEVENTREG_GATEKEEPER_OPENED_GORON_SHRINE_FOR_ZORA;
+    // Goron shrine Gatekeeper has opened shrine for player in Goron form.
+    BitField<2, 1, u8> WEEKEVENTREG_GATEKEEPER_OPENED_GORON_SHRINE_FOR_GORON;
+    // Unconfirmed: "Postman has delivered priority mail"
+    BitField<3, 1, u8> WEEKEVENTREG_89_08;
+    // If the player isn't in the ranch when this happens, then this weekeventreg will remain unset.
+    BitField<4, 1, u8> WEEKEVENTREG_FAILED_TO_DEFEND_AGAINST_ALIENS;
+    BitField<5, 1, u8> WEEKEVENTREG_89_20;
+    // Unconfirmed: "Postman is about to flee"
+    BitField<6, 1, u8> WEEKEVENTREG_89_40;
+    BitField<7, 1, u8> WEEKEVENTREG_89_80;
+  };
+
+  union WeekEventReg90 {
+    u8 raw;
+    // Unconfirmed: "Postman fleeing town"
+    BitField<0, 1, u8> WEEKEVENTREG_90_01;
+    BitField<1, 1, u8> WEEKEVENTREG_90_02;
+    BitField<2, 1, u8> WEEKEVENTREG_90_04;
+    BitField<3, 1, u8> WEEKEVENTREG_90_08;
+    BitField<4, 1, u8> WEEKEVENTREG_RECEIVED_GOSSIP_STONE_GROTTO_HEART_PIECE;
+    // Related to Fishermans's jumping minigame
+    BitField<5, 1, u8> WEEKEVENTREG_90_20;
+    BitField<6, 1, u8> WEEKEVENTREG_90_40;
+    BitField<7, 1, u8> WEEKEVENTREG_90_80;
+  };
+
+  union WeekEventReg91 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_91_01;
+    BitField<1, 1, u8> WEEKEVENTREG_91_02;
+    // Mikau Dialog flags may exist here.
+    BitField<2, 1, u8> WEEKEVENTREG_91_04;
+    BitField<3, 1, u8> WEEKEVENTREG_91_08;
+    BitField<4, 1, u8> WEEKEVENTREG_91_10;
+    BitField<5, 1, u8> WEEKEVENTREG_91_20;
+    BitField<6, 1, u8> WEEKEVENTREG_91_40;
+    BitField<7, 1, u8> WEEKEVENTREG_91_80;
+  };
+
+  union WeekEventReg92 {
+    u8 raw;
+    // HORSE_RACE_STATE (3 entries)
+    BitField<0, 1, u8> WEEKEVENTREG_92_01;
+    BitField<1, 1, u8> WEEKEVENTREG_92_02;
+    BitField<2, 1, u8> WEEKEVENTREG_92_04;
+
+
+    BitField<3, 1, u8> WEEKEVENTREG_92_08;
+    BitField<4, 1, u8> WEEKEVENTREG_92_10;
+    BitField<5, 1, u8> WEEKEVENTREG_92_20;
+    BitField<6, 1, u8> WEEKEVENTREG_92_40;
+    BitField<7, 1, u8> WEEKEVENTREG_92_80;
+  };
+
+  union WeekEventReg93 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_93_01;
+    BitField<1, 1, u8> WEEKEVENTREG_93_02;
+    BitField<2, 1, u8> WEEKEVENTREG_93_04;
+    BitField<3, 1, u8> WEEKEVENTREG_93_08;
+    BitField<4, 1, u8> WEEKEVENTREG_93_10;
+    BitField<5, 1, u8> WEEKEVENTREG_93_20;
+    BitField<6, 1, u8> WEEKEVENTREG_93_40;
+    BitField<7, 1, u8> WEEKEVENTREG_93_80;
+  };
+
+  union WeekEventReg94 {
+    u8 raw;
+    // Song of healing talked to actor flags maybe
+    BitField<0, 1, u8> WEEKEVENTREG_94_01;
+    BitField<1, 1, u8> WEEKEVENTREG_94_02;
+    BitField<2, 1, u8> WEEKEVENTREG_94_04;
+    BitField<3, 1, u8> WEEKEVENTREG_94_08;
+    BitField<4, 1, u8> WEEKEVENTREG_94_10;
+    BitField<5, 1, u8> WEEKEVENTREG_94_20;
+    BitField<6, 1, u8> WEEKEVENTREG_94_40;
+    BitField<7, 1, u8> WEEKEVENTREG_94_80;
+  };
+
+  union WeekEventReg95 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_95_01;
+    BitField<1, 1, u8> WEEKEVENTREG_95_02;
+    BitField<2, 1, u8> WEEKEVENTREG_95_04;
+    BitField<3, 1, u8> WEEKEVENTREG_95_08;
+    BitField<4, 1, u8> WEEKEVENTREG_95_10;
+    BitField<5, 1, u8> WEEKEVENTREG_95_20;
+    BitField<6, 1, u8> WEEKEVENTREG_95_40;
+    BitField<7, 1, u8> WEEKEVENTREG_95_80;
+  };
+
+  union WeekEventReg96 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_96_01;
+    BitField<1, 1, u8> WEEKEVENTREG_96_02;
+    BitField<2, 1, u8> WEEKEVENTREG_96_04;
+    BitField<3, 1, u8> WEEKEVENTREG_96_08;
+    BitField<4, 1, u8> WEEKEVENTREG_96_10;
+    BitField<5, 1, u8> WEEKEVENTREG_96_20;
+    BitField<6, 1, u8> WEEKEVENTREG_96_40;
+    BitField<7, 1, u8> WEEKEVENTREG_96_80;
+  };
+
+  union WeekEventReg97 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_97_01;
+    BitField<1, 1, u8> WEEKEVENTREG_97_02;
+    BitField<2, 1, u8> WEEKEVENTREG_97_04;
+    BitField<3, 1, u8> WEEKEVENTREG_97_08;
+    BitField<4, 1, u8> WEEKEVENTREG_97_10;
+    BitField<5, 1, u8> WEEKEVENTREG_97_20;
+    BitField<6, 1, u8> WEEKEVENTREG_97_40;
+    BitField<7, 1, u8> WEEKEVENTREG_97_80;
+  };
+
+  union WeekEventReg98 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_98_01;
+    BitField<1, 1, u8> WEEKEVENTREG_98_02;
+    BitField<2, 1, u8> WEEKEVENTREG_98_04;
+    BitField<3, 1, u8> WEEKEVENTREG_98_08;
+    BitField<4, 1, u8> WEEKEVENTREG_98_10;
+    BitField<5, 1, u8> WEEKEVENTREG_98_20;
+    BitField<6, 1, u8> WEEKEVENTREG_98_40;
+    BitField<7, 1, u8> WEEKEVENTREG_98_80;
+  };
+
+  union WeekEventReg99 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_99_01;
+    BitField<1, 1, u8> WEEKEVENTREG_99_02;
+    BitField<2, 1, u8> WEEKEVENTREG_99_04;
+    BitField<3, 1, u8> WEEKEVENTREG_99_08;
+    BitField<4, 1, u8> WEEKEVENTREG_99_10;
+    BitField<5, 1, u8> WEEKEVENTREG_99_20;
+    BitField<6, 1, u8> WEEKEVENTREG_99_40;
+    BitField<7, 1, u8> WEEKEVENTREG_99_80;
+  };
+
+  union WeekEventReg100 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_100_01;
+    BitField<1, 1, u8> WEEKEVENTREG_100_02;
+    BitField<2, 1, u8> WEEKEVENTREG_100_04;
+    BitField<3, 1, u8> WEEKEVENTREG_100_08;
+    BitField<4, 1, u8> WEEKEVENTREG_100_10;
+    BitField<5, 1, u8> WEEKEVENTREG_100_20;
+    BitField<6, 1, u8> WEEKEVENTREG_100_40;
+    BitField<7, 1, u8> WEEKEVENTREG_100_80;
+  };
+
+  union WeekEventReg101 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_101_01;
+    BitField<1, 1, u8> WEEKEVENTREG_101_02;
+    BitField<2, 1, u8> WEEKEVENTREG_101_04;
+    BitField<3, 1, u8> WEEKEVENTREG_101_08;
+    BitField<4, 1, u8> WEEKEVENTREG_101_10;
+    BitField<5, 1, u8> WEEKEVENTREG_101_20;
+    BitField<6, 1, u8> WEEKEVENTREG_101_40;
+    BitField<7, 1, u8> WEEKEVENTREG_101_80;
+  };
+
+  union WeekEventReg102 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_102_01;
+    BitField<1, 1, u8> WEEKEVENTREG_102_02;
+    BitField<2, 1, u8> WEEKEVENTREG_102_04;
+    BitField<3, 1, u8> WEEKEVENTREG_102_08;
+    BitField<4, 1, u8> WEEKEVENTREG_102_10;
+    BitField<5, 1, u8> WEEKEVENTREG_102_20;
+    BitField<6, 1, u8> WEEKEVENTREG_102_40;
+    BitField<7, 1, u8> WEEKEVENTREG_102_80;
+  };
+
+  union WeekEventReg103 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_103_01;
+    BitField<1, 1, u8> WEEKEVENTREG_103_02;
+    BitField<2, 1, u8> WEEKEVENTREG_103_04;
+    BitField<3, 1, u8> WEEKEVENTREG_103_08;
+    BitField<4, 1, u8> WEEKEVENTREG_103_10;
+    BitField<5, 1, u8> WEEKEVENTREG_103_20;
+    BitField<6, 1, u8> WEEKEVENTREG_103_40;
+    BitField<7, 1, u8> WEEKEVENTREG_103_80;
+  };
+
+  union WeekEventReg104 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_104_01;
+    BitField<1, 1, u8> WEEKEVENTREG_104_02;
+    BitField<2, 1, u8> WEEKEVENTREG_104_04;
+    BitField<3, 1, u8> WEEKEVENTREG_104_08;
+    BitField<4, 1, u8> WEEKEVENTREG_104_10;
+    BitField<5, 1, u8> WEEKEVENTREG_104_20;
+    BitField<6, 1, u8> WEEKEVENTREG_104_40;
+    BitField<7, 1, u8> WEEKEVENTREG_104_80;
+  };
+
+  union WeekEventReg105 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_105_01;
+    BitField<1, 1, u8> WEEKEVENTREG_105_02;
+    BitField<2, 1, u8> WEEKEVENTREG_105_04;
+    BitField<3, 1, u8> WEEKEVENTREG_105_08;
+    BitField<4, 1, u8> WEEKEVENTREG_105_10;
+    BitField<5, 1, u8> WEEKEVENTREG_105_20;
+    BitField<6, 1, u8> WEEKEVENTREG_105_40;
+    BitField<7, 1, u8> WEEKEVENTREG_105_80;
+  };
+
+  union WeekEventReg106 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_106_01;
+    BitField<1, 1, u8> WEEKEVENTREG_106_02;
+    BitField<2, 1, u8> WEEKEVENTREG_106_04;
+    BitField<3, 1, u8> WEEKEVENTREG_106_08;
+    BitField<4, 1, u8> WEEKEVENTREG_106_10;
+    BitField<5, 1, u8> WEEKEVENTREG_106_20;
+    BitField<6, 1, u8> WEEKEVENTREG_106_40;
+    BitField<7, 1, u8> WEEKEVENTREG_106_80;
+  };
+
+  union WeekEventReg107 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_107_01;
+    BitField<1, 1, u8> WEEKEVENTREG_107_02;
+    BitField<2, 1, u8> WEEKEVENTREG_107_04;
+    BitField<3, 1, u8> WEEKEVENTREG_107_08;
+    BitField<4, 1, u8> WEEKEVENTREG_107_10;
+    BitField<5, 1, u8> WEEKEVENTREG_107_20;
+    BitField<6, 1, u8> WEEKEVENTREG_107_40;
+    BitField<7, 1, u8> WEEKEVENTREG_107_80;
+  };
+
+  union WeekEventReg108 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_108_01;
+    BitField<1, 1, u8> WEEKEVENTREG_108_02;
+    BitField<2, 1, u8> WEEKEVENTREG_108_04;
+    BitField<3, 1, u8> WEEKEVENTREG_108_08;
+    BitField<4, 1, u8> WEEKEVENTREG_108_10;
+    BitField<5, 1, u8> WEEKEVENTREG_108_20;
+    BitField<6, 1, u8> WEEKEVENTREG_108_40;
+    BitField<7, 1, u8> WEEKEVENTREG_108_80;
+  };
+
+  union WeekEventReg109 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_109_01;
+    BitField<1, 1, u8> WEEKEVENTREG_109_02;
+    BitField<2, 1, u8> WEEKEVENTREG_109_04;
+    BitField<3, 1, u8> WEEKEVENTREG_109_08;
+    BitField<4, 1, u8> WEEKEVENTREG_109_10;
+    BitField<5, 1, u8> WEEKEVENTREG_109_20;
+    BitField<6, 1, u8> WEEKEVENTREG_109_40;
+    BitField<7, 1, u8> WEEKEVENTREG_109_80;
+  };
+
+  union WeekEventReg110 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_110_01;
+    BitField<1, 1, u8> WEEKEVENTREG_110_02;
+    BitField<2, 1, u8> WEEKEVENTREG_110_04;
+    BitField<3, 1, u8> WEEKEVENTREG_110_08;
+    BitField<4, 1, u8> WEEKEVENTREG_110_10;
+    BitField<5, 1, u8> WEEKEVENTREG_110_20;
+    BitField<6, 1, u8> WEEKEVENTREG_110_40;
+    BitField<7, 1, u8> WEEKEVENTREG_110_80;
+  };
+
+  union WeekEventReg111 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_111_01;
+    BitField<1, 1, u8> WEEKEVENTREG_111_02;
+    BitField<2, 1, u8> WEEKEVENTREG_111_04;
+    BitField<3, 1, u8> WEEKEVENTREG_111_08;
+    BitField<4, 1, u8> WEEKEVENTREG_111_10;
+    BitField<5, 1, u8> WEEKEVENTREG_111_20;
+    BitField<6, 1, u8> WEEKEVENTREG_111_40;
+    BitField<7, 1, u8> WEEKEVENTREG_111_80;
+  };
+
+  union WeekEventReg112 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_112_01;
+    BitField<1, 1, u8> WEEKEVENTREG_112_02;
+    BitField<2, 1, u8> WEEKEVENTREG_112_04;
+    BitField<3, 1, u8> WEEKEVENTREG_112_08;
+    BitField<4, 1, u8> WEEKEVENTREG_112_10;
+    BitField<5, 1, u8> WEEKEVENTREG_112_20;
+    BitField<6, 1, u8> WEEKEVENTREG_112_40;
+    BitField<7, 1, u8> WEEKEVENTREG_112_80;
+  };
+
+  union WeekEventReg113 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_113_01;
+    BitField<1, 1, u8> WEEKEVENTREG_113_02;
+    BitField<2, 1, u8> WEEKEVENTREG_113_04;
+    BitField<3, 1, u8> WEEKEVENTREG_113_08;
+    BitField<4, 1, u8> WEEKEVENTREG_113_10;
+    BitField<5, 1, u8> WEEKEVENTREG_113_20;
+    BitField<6, 1, u8> WEEKEVENTREG_113_40;
+    BitField<7, 1, u8> WEEKEVENTREG_113_80;
+  };
+
+  union WeekEventReg114 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_114_01;
+    BitField<1, 1, u8> WEEKEVENTREG_114_02;
+    BitField<2, 1, u8> WEEKEVENTREG_114_04;
+    BitField<3, 1, u8> WEEKEVENTREG_114_08;
+    BitField<4, 1, u8> WEEKEVENTREG_114_10;
+    BitField<5, 1, u8> WEEKEVENTREG_114_20;
+    BitField<6, 1, u8> WEEKEVENTREG_114_40;
+    BitField<7, 1, u8> WEEKEVENTREG_114_80;
+  };
+
+  union WeekEventReg115 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_115_01;
+    BitField<1, 1, u8> WEEKEVENTREG_115_02;
+    BitField<2, 1, u8> WEEKEVENTREG_115_04;
+    BitField<3, 1, u8> WEEKEVENTREG_115_08;
+    BitField<4, 1, u8> WEEKEVENTREG_115_10;
+    BitField<5, 1, u8> WEEKEVENTREG_115_20;
+    BitField<6, 1, u8> WEEKEVENTREG_115_40;
+    BitField<7, 1, u8> WEEKEVENTREG_115_80;
+  };
+
+  union WeekEventReg116 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_116_01;
+    BitField<1, 1, u8> WEEKEVENTREG_116_02;
+    BitField<2, 1, u8> WEEKEVENTREG_116_04;
+    BitField<3, 1, u8> WEEKEVENTREG_116_08;
+    BitField<4, 1, u8> WEEKEVENTREG_116_10;
+    BitField<5, 1, u8> WEEKEVENTREG_116_20;
+    BitField<6, 1, u8> WEEKEVENTREG_116_40;
+    BitField<7, 1, u8> WEEKEVENTREG_116_80;
+  };
+
+  union WeekEventReg117 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_117_01;
+    BitField<1, 1, u8> WEEKEVENTREG_117_02;
+    BitField<2, 1, u8> WEEKEVENTREG_117_04;
+    BitField<3, 1, u8> WEEKEVENTREG_117_08;
+    BitField<4, 1, u8> WEEKEVENTREG_117_10;
+    BitField<5, 1, u8> WEEKEVENTREG_117_20;
+    BitField<6, 1, u8> WEEKEVENTREG_117_40;
+    BitField<7, 1, u8> WEEKEVENTREG_117_80;
+  };
+
+  union WeekEventReg118 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_118_01;
+    BitField<1, 1, u8> WEEKEVENTREG_118_02;
+    BitField<2, 1, u8> WEEKEVENTREG_118_04;
+    BitField<3, 1, u8> WEEKEVENTREG_118_08;
+    BitField<4, 1, u8> WEEKEVENTREG_118_10;
+    BitField<5, 1, u8> WEEKEVENTREG_118_20;
+    BitField<6, 1, u8> WEEKEVENTREG_118_40;
+    BitField<7, 1, u8> WEEKEVENTREG_118_80;
+  };
+
+  union WeekEventReg119 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_119_01;
+    BitField<1, 1, u8> WEEKEVENTREG_119_02;
+    BitField<2, 1, u8> WEEKEVENTREG_119_04;
+    BitField<3, 1, u8> WEEKEVENTREG_119_08;
+    BitField<4, 1, u8> WEEKEVENTREG_119_10;
+    BitField<5, 1, u8> WEEKEVENTREG_119_20;
+    BitField<6, 1, u8> WEEKEVENTREG_119_40;
+    BitField<7, 1, u8> WEEKEVENTREG_119_80;
+  };
+
+  union WeekEventReg120 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_120_01;
+    BitField<1, 1, u8> WEEKEVENTREG_120_02;
+    BitField<2, 1, u8> WEEKEVENTREG_120_04;
+    BitField<3, 1, u8> WEEKEVENTREG_120_08;
+    BitField<4, 1, u8> WEEKEVENTREG_120_10;
+    BitField<5, 1, u8> WEEKEVENTREG_120_20;
+    BitField<6, 1, u8> WEEKEVENTREG_120_40;
+    BitField<7, 1, u8> WEEKEVENTREG_120_80;
+  };
+
+  union WeekEventReg121 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_121_01;
+    BitField<1, 1, u8> WEEKEVENTREG_121_02;
+    BitField<2, 1, u8> WEEKEVENTREG_121_04;
+    BitField<3, 1, u8> WEEKEVENTREG_121_08;
+    BitField<4, 1, u8> WEEKEVENTREG_121_10;
+    BitField<5, 1, u8> WEEKEVENTREG_121_20;
+    BitField<6, 1, u8> WEEKEVENTREG_121_40;
+    BitField<7, 1, u8> WEEKEVENTREG_121_80;
+  };
+
+  union WeekEventReg122 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_122_01;
+    BitField<1, 1, u8> WEEKEVENTREG_122_02;
+    BitField<2, 1, u8> WEEKEVENTREG_122_04;
+    BitField<3, 1, u8> WEEKEVENTREG_122_08;
+    BitField<4, 1, u8> WEEKEVENTREG_122_10;
+    BitField<5, 1, u8> WEEKEVENTREG_122_20;
+    BitField<6, 1, u8> WEEKEVENTREG_122_40;
+    BitField<7, 1, u8> WEEKEVENTREG_122_80;
+  };
+
+  union WeekEventReg123 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_123_01;
+    BitField<1, 1, u8> WEEKEVENTREG_123_02;
+    BitField<2, 1, u8> WEEKEVENTREG_123_04;
+    BitField<3, 1, u8> WEEKEVENTREG_123_08;
+    BitField<4, 1, u8> WEEKEVENTREG_123_10;
+    BitField<5, 1, u8> WEEKEVENTREG_123_20;
+    BitField<6, 1, u8> WEEKEVENTREG_123_40;
+    BitField<7, 1, u8> WEEKEVENTREG_123_80;
+  };
+
+  union WeekEventReg124 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_124_01;
+    BitField<1, 1, u8> WEEKEVENTREG_124_02;
+    BitField<2, 1, u8> WEEKEVENTREG_124_04;
+    BitField<3, 1, u8> WEEKEVENTREG_124_08;
+    BitField<4, 1, u8> WEEKEVENTREG_124_10;
+    BitField<5, 1, u8> WEEKEVENTREG_124_20;
+    BitField<6, 1, u8> WEEKEVENTREG_124_40;
+    BitField<7, 1, u8> WEEKEVENTREG_124_80;
+  };
+
+  union WeekEventReg125 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_125_01;
+    BitField<1, 1, u8> WEEKEVENTREG_125_02;
+    BitField<2, 1, u8> WEEKEVENTREG_125_04;
+    BitField<3, 1, u8> WEEKEVENTREG_125_08;
+    BitField<4, 1, u8> WEEKEVENTREG_125_10;
+    BitField<5, 1, u8> WEEKEVENTREG_125_20;
+    BitField<6, 1, u8> WEEKEVENTREG_125_40;
+    BitField<7, 1, u8> WEEKEVENTREG_125_80;
+  };
+
+  union WeekEventReg126 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_126_01;
+    BitField<1, 1, u8> WEEKEVENTREG_126_02;
+    BitField<2, 1, u8> WEEKEVENTREG_126_04;
+    BitField<3, 1, u8> WEEKEVENTREG_126_08;
+    BitField<4, 1, u8> WEEKEVENTREG_126_10;
+    BitField<5, 1, u8> WEEKEVENTREG_126_20;
+    BitField<6, 1, u8> WEEKEVENTREG_126_40;
+    BitField<7, 1, u8> WEEKEVENTREG_126_80;
+  };
+
+  union WeekEventReg127 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_127_01;
+    BitField<1, 1, u8> WEEKEVENTREG_127_02;
+    BitField<2, 1, u8> WEEKEVENTREG_127_04;
+    BitField<3, 1, u8> WEEKEVENTREG_127_08;
+    BitField<4, 1, u8> WEEKEVENTREG_127_10;
+    BitField<5, 1, u8> WEEKEVENTREG_127_20;
+    BitField<6, 1, u8> WEEKEVENTREG_127_40;
+    BitField<7, 1, u8> WEEKEVENTREG_127_80;
+  };
+
+  union WeekEventReg128 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_128_01;
+    BitField<1, 1, u8> WEEKEVENTREG_128_02;
+    BitField<2, 1, u8> WEEKEVENTREG_128_04;
+    BitField<3, 1, u8> WEEKEVENTREG_128_08;
+    BitField<4, 1, u8> WEEKEVENTREG_128_10;
+    BitField<5, 1, u8> WEEKEVENTREG_128_20;
+    BitField<6, 1, u8> WEEKEVENTREG_128_40;
+    BitField<7, 1, u8> WEEKEVENTREG_128_80;
+  };
+
+  union WeekEventReg129 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_129_01;
+    BitField<1, 1, u8> WEEKEVENTREG_129_02;
+    BitField<2, 1, u8> WEEKEVENTREG_129_04;
+    BitField<3, 1, u8> WEEKEVENTREG_129_08;
+    BitField<4, 1, u8> WEEKEVENTREG_129_10;
+    BitField<5, 1, u8> WEEKEVENTREG_129_20;
+    BitField<6, 1, u8> WEEKEVENTREG_129_40;
+    BitField<7, 1, u8> WEEKEVENTREG_129_80;
+  };
+
+  union WeekEventReg130 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_OWL_STATUE_CUTSCENE;
+    BitField<1, 1, u8> WEEKEVENTREG_130_02;
+    BitField<2, 1, u8> WEEKEVENTREG_130_04;
+    BitField<3, 1, u8> WEEKEVENTREG_SKIP_MAP_TUTORIAL_BY_TINGLE;
+    BitField<4, 1, u8> WEEKEVENTREG_DEKU_THRONE_ROOM_CAMERA_PAN;
+    BitField<5, 1, u8> WEEKEVENTREG_TATL_MOON_TEAR_DIALOGUE;
+    BitField<6, 1, u8> WEEKEVENTREG_130_40;
+    BitField<7, 1, u8> WEEKEVENTREG_130_80;
+  };
+
+  union WeekEventReg131 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_131_01;
+    BitField<1, 1, u8> WEEKEVENTREG_131_02;
+    BitField<2, 1, u8> WEEKEVENTREG_131_04;
+    BitField<3, 1, u8> WEEKEVENTREG_131_08;
+    BitField<4, 1, u8> WEEKEVENTREG_131_10;
+    BitField<5, 1, u8> WEEKEVENTREG_131_20;
+    BitField<6, 1, u8> WEEKEVENTREG_131_40;
+    BitField<7, 1, u8> WEEKEVENTREG_131_80;
+  };
+
+  union WeekEventReg132 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_132_01;
+    BitField<1, 1, u8> WEEKEVENTREG_132_02;
+    BitField<2, 1, u8> WEEKEVENTREG_132_04;
+    BitField<3, 1, u8> WEEKEVENTREG_132_08;
+    BitField<4, 1, u8> WEEKEVENTREG_SKIP_WOODFALL_PORTAL_CUTSCENE;
+    BitField<5, 1, u8> WEEKEVENTREG_SKIP_SNOWHEAD_PORTAL_CUTSCENE;
+    BitField<6, 1, u8> WEEKEVENTREGSKIP_GREAT_BAY_PORTAL_CUTSCENE;
+    BitField<7, 1, u8> WEEKEVENTREG_SKIP_STT_PORTAL_CUTSCENE;
+    
+  };
+
+  union WeekEventReg133 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_133_01;
+    BitField<1, 1, u8> WEEKEVENTREG_133_02;
+    BitField<2, 1, u8> WEEKEVENTREG_133_04;
+    BitField<3, 1, u8> WEEKEVENTREG_133_08;
+    BitField<4, 1, u8> WEEKEVENTREG_133_10;
+    BitField<5, 1, u8> WEEKEVENTREG_133_20;
+    BitField<6, 1, u8> WEEKEVENTREG_133_40;
+    BitField<7, 1, u8> WEEKEVENTREG_133_80;
+  };
+
+  union WeekEventReg134 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_134_01;
+    BitField<1, 1, u8> WEEKEVENTREG_134_02;
+    BitField<2, 1, u8> WEEKEVENTREG_134_04;
+    BitField<3, 1, u8> WEEKEVENTREG_134_08;
+    BitField<4, 1, u8> WEEKEVENTREG_134_10;
+    BitField<5, 1, u8> WEEKEVENTREG_134_20;
+    BitField<6, 1, u8> WEEKEVENTREG_134_40;
+    BitField<7, 1, u8> WEEKEVENTREG_134_80;
+  };
+
+  union WeekEventReg135 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_135_01;
+    BitField<1, 1, u8> WEEKEVENTREG_135_02;
+    BitField<2, 1, u8> WEEKEVENTREG_135_04;
+    BitField<3, 1, u8> WEEKEVENTREG_135_08;
+    BitField<4, 1, u8> WEEKEVENTREG_135_10;
+    BitField<5, 1, u8> WEEKEVENTREG_135_20;
+    BitField<6, 1, u8> WEEKEVENTREG_135_40;
+    BitField<7, 1, u8> WEEKEVENTREG_135_80;
+  };
+
+  union WeekEventReg136 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_136_01;
+    BitField<1, 1, u8> WEEKEVENTREG_136_02;
+    BitField<2, 1, u8> WEEKEVENTREG_136_04;
+    BitField<3, 1, u8> WEEKEVENTREG_CAMERA_PAN_WOODFALL_ENTER;
+    BitField<4, 1, u8> WEEKEVENTREG_136_10;
+    BitField<5, 1, u8> WEEKEVENTREG_136_20;
+    BitField<6, 1, u8> WEEKEVENTREG_136_40;
+    BitField<7, 1, u8> WEEKEVENTREG_136_80;
+  };
+
+  union WeekEventReg137 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_137_01;
+    BitField<1, 1, u8> WEEKEVENTREG_137_02;
+    BitField<2, 1, u8> WEEKEVENTREG_137_04;
+    BitField<3, 1, u8> WEEKEVENTREG_SONG_OF_SOARING_PLAYED;
+    BitField<4, 1, u8> WEEKEVENTREG_WOODFALL_TEMPLE_OPENED;
+    BitField<5, 1, u8> WEEKEVENTREG_SNOWHEAD_TEMPLE_OPENED;
+    BitField<6, 1, u8> WEEKEVENTREG_GREAT_BAY_TEMPLE_OPENED;
+    BitField<7, 1, u8> WEEKEVENTREG_DEKU_FLOWN_IN;
+  };
+
+  union WeekEventReg138 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_138_01;
+    BitField<1, 1, u8> WEEKEVENTREG_138_02;
+    BitField<2, 1, u8> WEEKEVENTREG_138_04;
+    BitField<3, 1, u8> WEEKEVENTREG_138_08;
+    BitField<4, 1, u8> WEEKEVENTREG_138_10;
+    BitField<5, 1, u8> WEEKEVENTREG_138_20;
+    BitField<6, 1, u8> WEEKEVENTREG_138_40;
+    BitField<7, 1, u8> WEEKEVENTREG_138_80;
+  };
+
+  union WeekEventReg139 {
+    u8 raw;
+    BitField<0, 1, u8> WEEKEVENTREG_139_01;
+    BitField<1, 1, u8> WEEKEVENTREG_139_02;
+    BitField<2, 1, u8> WEEKEVENTREG_139_04;
+    BitField<3, 1, u8> WEEKEVENTREG_139_08;
+    BitField<4, 1, u8> WEEKEVENTREG_139_10;
+    BitField<5, 1, u8> WEEKEVENTREG_139_20;
+    BitField<6, 1, u8> WEEKEVENTREG_139_40;
+    BitField<7, 1, u8> WEEKEVENTREG_139_80;
+  };
+}
+
+#endif  // _GAME_WEEK_EVENT_REG_H

--- a/code/include/rnd/input.h
+++ b/code/include/rnd/input.h
@@ -10,6 +10,7 @@ namespace rnd {
     btn_t up;
     btn_t pressed;
     btn_t old;
+    cp_t cp_curr;
   } InputContext;
 
   void Input_Update(void);

--- a/code/include/rnd/item_override.h
+++ b/code/include/rnd/item_override.h
@@ -104,7 +104,7 @@ namespace rnd {
     /* 0x4D */  // GI_ERROR_NOTHING_4D, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                 // Ocarina in Inventory
     /* 0x4E */  // GI_ERROR_NOTHING_4E, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
+                // Ocarina in Inventory - New Wave Bossa Nova
     /* 0x4F */  // GI_ERROR_NOTHING_4F, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                 // Ocarina in Inventory
     /* 0x50 */ GI_BOMBERS_NOTEBOOK = 0x50,
@@ -112,7 +112,7 @@ namespace rnd {
                 // subsequently yellow rupee. No rupee increment.
     /* 0x52 */ GI_GOLD_SKULLTULA_SPIRIT = 0x52,  // Pickup model is whacky since we usually don't have one.
     /* 0x53 */  // GI_ERROR_NOTHING_53, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
+                // Ocarina in Inventory Song of Time
     /* 0x54 */  // GI_ERROR_NOTHING_54, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                 // Ocarina in Inventory
     /* 0x55 */ GI_ODOLWAS_REMAINS = 0x55,  // Also softlocks!
@@ -146,7 +146,7 @@ namespace rnd {
     /* 0x70 */ GI_BOTTLE_MYSTERY_MILK,  // Activates Timer
     /* 0x71 */ GI_BOTTLE_MOLDY_MILK,    // Mystery milk text followed by tatl.
     /* 0x72 */  // GI_ERROR_NOTHING_72, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
+                // Ocarina in Inventory. Song of Soaring.
     /* 0x73 */  // GI_ERROR_NOTHING_73, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                 // Ocarina in Inventory
     /* 0x74 */  // GI_ERROR_NOTHING_74, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
@@ -448,9 +448,9 @@ namespace rnd {
   void ItemOverride_GetItemTextAndItemID(game::act::Player*);
   void ItemOverride_GetItem(game::GlobalContext*, game::act::Actor*, game::act::Player*, s16);
   void ItemOverride_GetFairyRewardItem(game::GlobalContext*, game::act::GreatFairy*, s16);
-  void ItemOverride_GetSoHItem(game::GlobalContext*, game::act::Actor*, s16);
+  void ItemOverride_GetSoHOrSongItem(game::GlobalContext*, game::act::Actor*, s16);
   int ItemOverride_CheckInventoryItemOverride(game::ItemId);
-  void ItemOverride_SwapSoHGetItemText(game::GlobalContext*, u16, game::act::Actor*);
+  void ItemOverride_SwapSoHAndSongGetItemText(game::GlobalContext*, u16, game::act::Actor*);
   bool ItemOverride_CheckTingleMaps(u16, game::GlobalContext*);
   u32 ItemOverride_GetGaboraExtData();
   u32 ItemOverride_GetOshExtData();
@@ -459,6 +459,8 @@ namespace rnd {
   u8 ItemOverride_OverrideSkullToken(game::act::Actor*);
   u8 ItemOverride_CheckBossStatus();
   u8 ItemOverride_ReceivedOcarinaFromSkt();
+  u8 ItemOverride_ReceivedSongOverride(s16);
+  u8 ItemOverride_CheckIfSongOfTimeAwarded(u8);
   }
   extern "C" u32 rActiveItemGraphicId;
   extern "C" ItemOverride rItemOverrides[640];

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -110,6 +110,23 @@ namespace rnd {
       BitField<59, 5, u64> unused;
     };
     GivenItemRegister givenItemChecks;
+    union GivenSongRegister {
+      u16 raw;
+
+      BitField<0, 1, u16> sonataGiven;
+      BitField<1, 1, u16> goronLullabyGiven;
+      BitField<2, 1, u16> goronLullabyIntroGiven;
+      BitField<3, 1, u16> newWaveBossaNovaGiven;
+      BitField<4, 1, u16> elegyOfEmptinessGiven;
+      BitField<5, 1, u16> oathToOrderGiven;
+      BitField<6, 1, u16> songOfTimeGiven;
+      BitField<7, 1, u16> songOfHealingGiven;
+      BitField<8, 1, u16> eponasSongGiven;
+      BitField<9, 1, u16> songOfSoaringGiven;
+      BitField<10, 1, u16> songOfStormsGiven;
+      BitField<11, 5, u16> unused;
+    };
+    GivenSongRegister givenSongChecks;
     union FairyCollectRegister {
       u8 raw;
 

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -53,12 +53,16 @@ SECTIONS{
     *(.patch_PostActorCalc)
   }
 
+  .patch_ResetCycleFlagOnMoonCrash 0x1851C0 : {
+    *(.patch_ResetCycleFlagOnMoonCrash)
+  }
+
   .patch_RemoveCouplesMaskMessage 0x1867C4 : {
     *(.patch_RemoveCouplesMaskMessage)
   }
 
-  .patch_RemoveSOHCutesceneAfterMessage 0x186810 : {
-    *(.patch_RemoveSOHCutesceneAfterMessage)
+  .patch_OverrideSoHAndSongText 0x186810 : {
+    *(.patch_OverrideSoHAndSongText)
   }
 
   .patch_OverrideBombersNotebook 0x186ACC : {
@@ -163,6 +167,10 @@ SECTIONS{
 
   .patch_RemoveMysteryMilkSoSCheck 0x1D79F8 : {
     *(.patch_RemoveMysteryMilkSoSCheck)
+  }
+
+  .patch_CheckExtForSongOfTime 0x1D7FEC : {
+    *(.patch_CheckExtForSongOfTime)
   }
 
   .patch_DoNotForceMaskChange 0x1DB314 : {
@@ -317,6 +325,10 @@ SECTIONS{
     *(.patch_OverrideItemID)
   }
 
+  .patch_SongOfTimeCheckExtData 0x2311A4 : {
+   *(.patch_SongOfTimeCheckExtData) 
+  }
+
   .patch_ForceSwordUpgradeOnHuman 0x233D88 : {
     *(.patch_ForceSwordUpgradeOnHuman)
   }
@@ -347,6 +359,18 @@ SECTIONS{
 
   .patch_EnteringLocation 0x23AA54 : {
     *(.patch_EnteringLocation)
+  }
+
+  .patch_LullabyIntroCheckEnJg 0x244378 : {
+    *(.patch_LullabyIntroCheckEnJg)
+  }
+
+  .patch_LullabyCheckEnJg 0x244380 : {
+    *(.patch_LullabyCheckEnJg)
+  }
+
+  .patch_EnOsnCheckSoHExtData 0x268030 : {
+    *(.patch_EnOsnCheckSoHExtData)
   }
 
   .patch_TwinmoldConsistentDamage 0x28E544 : {
@@ -439,6 +463,18 @@ SECTIONS{
     *(.patch_RemoveGoronMaskCheckDarmani)
   }
 
+  .patch_EnMa4ExtDataCheckOne 0x2E3784 : {
+    *(.patch_EnMa4ExtDataCheckOne)
+  }
+
+  .patch_EnMa4ExtDataCheckThree 0x2E3CD0 : {
+      *(.patch_EnMa4ExtDataCheckThree)
+    }
+
+  .patch_EnMa4ExtDataCheckTwo 0x2E3D94 : {
+    *(.patch_EnMa4ExtDataCheckTwo)
+  }
+
   /* .patch_RemoveSkulltulaSpawnIfCollectedItem 0x2E8384 : {
     *(.patch_RemoveSkulltulaSpawnIfCollectedItem)
   } */
@@ -471,8 +507,16 @@ SECTIONS{
     *(.patch_AdjustMapAndCompassChests)
   }
 
+  .patch_EnMnkSongOverride 0x0325D58 : {
+    *(.patch_EnMnkSongOverride)
+  }
+
   .patch_RemoveSongCheckKaepora 0x326ED0 : {
     *(.patch_RemoveSongCheckKaepora)
+  }
+
+  .patch_RemoveSoSCheckKaepora 0x326EF8 : {
+    *(.patch_RemoveSoSCheckKaepora)
   }
 
   .patch_RemoveZoraMaskCheckMikau 0x32BBB8 : {
@@ -631,6 +675,10 @@ SECTIONS{
     *(.patch_OverrideItem00Draw)
   }
 
+  .patch_OverrideSoSGiveItem 0x43FB64 : {
+    *(.patch_OverrideSoSGiveItem)
+  }
+
   .patch_FierceDeityArcheryFix 0x4427E8 : {
     *(.patch_FierceDeityArcheryFix)
   }
@@ -698,6 +746,17 @@ SECTIONS{
 
   .patch_SkulltulaOverrideTwo 0x52A044 : {
     *(.patch_SkulltulaOverrideTwo)
+  }
+
+  .patch_EnGkCheckLullabyRewardGivenOne 0x546294 : {
+    *(.patch_EnGkCheckLullabyRewardGivenOne)
+  }
+
+  .patch_EnGkCheckLullabyRewardGivenTwo 0x546374 : {
+    *(.patch_EnGkCheckLullabyRewardGivenTwo)
+  }
+  .patch_EnMkNWBNOverride 0x58722C : {
+    *(.patch_EnMkNWBNOverride)
   }
 
   .patch_UpdateOcarinaVisibility 0x59AA2C : {
@@ -775,6 +834,10 @@ SECTIONS{
 
   .patch_HandleOcarinaHooks 0x604D8C : {
     *(.patch_HandleOcarinaHooks)
+  }
+
+  .patch_OverrideGetSongItem 0x60597C : {
+    *(.patch_OverrideGetSongItem)
   }
 
   .patch_FDOpenDungeonDoors 0x68D9C0 : {

--- a/code/source/asm/hms_hooks.s
+++ b/code/source/asm/hms_hooks.s
@@ -11,7 +11,7 @@ hook_OverrideHMSDekuMask:
     cpy r0,r5
     cpy r1,r4
     mov r2,#0x78
-    bl ItemOverride_GetSoHItem
+    bl ItemOverride_GetSoHOrSongItem
     ldr r5,.rActiveItemRow_addr
     ldr r5,[r5]
     cmp r5,#0x0
@@ -35,7 +35,7 @@ hook_OverrideHMSBombers:
     cpy r0,r6
     mov r1,#0x0
     mov r2,#0x50
-    bl ItemOverride_GetSoHItem
+    bl ItemOverride_GetSoHOrSongItem
     ldr r5,.rActiveItemRow_addr
     ldr r5,[r5]
     cmp r5,#0x0

--- a/code/source/asm/item_override_hooks.s
+++ b/code/source/asm/item_override_hooks.s
@@ -192,7 +192,7 @@ hook_GoronMaskGiveItem:
     cpy r0,r5
     cpy r1,r4
     mov r2,#0x79
-    bl ItemOverride_GetSoHItem
+    bl ItemOverride_GetSoHOrSongItem
     ldr r5,.rActiveItemRow_addr
     ldr r5,[r5]
     cmp r5,#0x0
@@ -216,7 +216,7 @@ hook_ZoraMaskGiveItem:
     cpy r0,r5
     cpy r1,r4
     mov r2,#0x7A
-    bl ItemOverride_GetSoHItem
+    bl ItemOverride_GetSoHOrSongItem
     ldr r5,.rActiveItemRow_addr
     ldr r5,[r5]
     cmp r5,#0x0
@@ -240,7 +240,7 @@ hook_GibdoMaskGiveItem:
     cpy r0,r5
     cpy r1,r4
     mov r2,#0x87
-    bl ItemOverride_GetSoHItem
+    bl ItemOverride_GetSoHOrSongItem
     ldr r5,.rActiveItemRow_addr
     ldr r5,[r5]
     cmp r5,#0x0
@@ -258,13 +258,40 @@ noOverrideGibdoItemID:
     bl 0x233BEC
     b 0x41DC4C
 
+.global hook_OverrideSoSGiveItem
+hook_OverrideSoSGiveItem:
+    cpy r0,r5
+    push {r0-r12, lr}
+    cpy r2,r1
+    mov r1,#0xFF
+    bl ItemOverride_GetSoHOrSongItem
+    ldr r5,.rActiveItemRow_addr
+    ldr r5,[r5]
+    cmp r5,#0x0
+    pop {r0-r12, lr}
+    beq noOverrideSoSGiveItem
+    push {r0-r12, lr}
+    ldr r0, [r5,#0xDC]
+    bl ItemOverride_GetItemTextAndItemID
+    pop {r0-r12, lr}
+    cpy r0,r5
+    b 0x43FB6C
+noOverrideSoSGiveItem:
+    push {r0-r12, lr}
+    cpy r0,r1
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    beq 0x233BEC
+    b 0x43FB6C
+
 .global hook_CouplesMaskGiveItem
 hook_CouplesMaskGiveItem:
     push {r0-r12, lr}
     cpy r0,r5
     cpy r1,r4
     mov r2,#0x85
-    bl ItemOverride_GetSoHItem
+    bl ItemOverride_GetSoHOrSongItem
     ldr r5,.rActiveItemRow_addr
     ldr r5,[r5]
     cmp r5,#0x0
@@ -297,10 +324,10 @@ normalText:
     mov r1,#0xA2
     b 0x1867C8
 
-.global hook_ChangeSOHToCustomText
-hook_ChangeSOHToCustomText:
+.global hook_ChangeSoHAndSongToCustomText
+hook_ChangeSoHAndSongToCustomText:
     push {r0-r2, lr}
-    bl ItemOverride_SwapSoHGetItemText
+    bl ItemOverride_SwapSoHAndSongGetItemText
     pop {r0-r2, lr}
     b 0x186814
 
@@ -329,3 +356,24 @@ hook_SkulltulaOverrideTwo:
     b 0x52A048
 skulltulaOverriddenTwo:
     b 0x52A06C
+
+
+.global hook_OverrideGetSongItem
+hook_OverrideGetSongItem:
+    push {r0-r12, lr}
+    cpy r2,r1
+    mov r1,#0xFF
+    bl ItemOverride_GetSoHOrSongItem
+    ldr r5,.rActiveItemRow_addr
+    ldr r5,[r5]
+    cmp r5,#0x0
+    pop {r0-r12, lr}
+    beq noOverrideSongItemID
+    push {r0-r12, lr}
+    ldr r0, [r0,#0xDC]
+    bl ItemOverride_GetItemTextAndItemID
+    pop {r0-r12, lr}
+    b 0x605980
+noOverrideSongItemID:
+    bl 0x233BEC
+    b 0x605980

--- a/code/source/asm/item_override_patches.s
+++ b/code/source/asm/item_override_patches.s
@@ -125,6 +125,11 @@ patch_ZoraMaskGiveItem:
 patch_GibdoMaskGiveItem:
     b hook_GibdoMaskGiveItem
 
+.section .patch_OverrideSoSGiveItem
+.global patch_OverrideSoSGiveItem
+patch_OverrideSoSGiveItem:
+    b hook_OverrideSoSGiveItem
+
 .section .patch_CouplesMaskGiveItem
 .global patch_CouplesMaskGiveItem
 patch_CouplesMaskGiveItem:
@@ -138,10 +143,10 @@ patch_RemoveCouplesMaskMessage:
 
 @ This should remove the overwriting message for when the
 @ user receives the Zora Mask.
-.section .patch_RemoveSOHCutesceneAfterMessage
-.global patch_RemoveSOHCutesceneAfterMessage
-patch_RemoveSOHCutesceneAfterMessage:
-    b hook_ChangeSOHToCustomText
+.section .patch_OverrideSoHAndSongText
+.global patch_OverrideSoHAndSongText
+patch_OverrideSoHAndSongText:
+    b hook_ChangeSoHAndSongToCustomText
 
 .section .patch_SkulltulaOverrideOne
 .global patch_SkulltulaOverrideOne
@@ -152,3 +157,9 @@ patch_SkulltulaOverrideOne:
 .global patch_SkulltulaOverrideTwo
 patch_SkulltulaOverrideTwo:
     bl hook_SkulltulaOverrideTwo
+
+
+.section .patch_OverrideGetSongItem
+.global patch_OverrideGetSongItem
+patch_OverrideGetSongItem:
+    b hook_OverrideGetSongItem

--- a/code/source/asm/ocarina_hooks.s
+++ b/code/source/asm/ocarina_hooks.s
@@ -19,7 +19,7 @@ hook_FixRemovingOcarinaFromInventory:
     add r0,r0,r1 @ original instruction
     b 0x201068
 ocarinaAlwaysInInventory:
-    mov r0, #0x0 @ Force the ocarina to always be in inventory
+    mov r0, #0x00 @ Force the ocarina to always be in inventory
     b 0x20106C
 
 .global hook_DmSktOcarinaAnimationPatchOne

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -19,6 +19,12 @@ patch_FixSurroundSound:
     nop
     nop
 
+@ Change 
+.section .patch_ResetCycleFlagOnMoonCrash
+.global patch_ResetCycleFlagOnMoonCrash
+patch_ResetCycleFlagOnMoonCrash:
+    bl 0x1C92A8
+
 @ nop gctx->field_22f8 from being potentially nulled. Disables stray fairy respawn and doors locking.
 .section .patch_DoNotResetPermFlags
 .global patch_DoNotResetPermFlags

--- a/code/source/asm/songsanity_hooks.s
+++ b/code/source/asm/songsanity_hooks.s
@@ -1,0 +1,143 @@
+.arm
+.text
+
+.global rActiveItemRow
+.rActiveItemRow_addr:
+    .word rActiveItemRow
+
+.global hook_CheckExtForSongOfTime
+hook_CheckExtForSongOfTime:
+    push {r0-r12, lr}
+    mov r0,#0x67
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    bx lr
+
+.global hook_SongOfTimeCheckExtData
+hook_SongOfTimeCheckExtData:
+    push {r0-r12, lr}
+    bl ItemOverride_CheckIfSongOfTimeAwarded
+    cmp r0,#0x4C
+    pop {r0-r12,lr}
+    bx lr
+
+.global hook_LullabyIntroCheckEnJg
+hook_LullabyIntroCheckEnJg:
+    push {r0-r12, lr}
+    mov r0, #0x73
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0, #0x0
+    pop {r0-r12, lr}    
+    bx lr
+
+.global hook_LullabyCheckEnJg
+hook_LullabyCheckEnJg:
+    push {r0-r12, lr}
+    mov r0, #0x62
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0, #0x0
+    pop {r0-r12, lr}    
+    bx lr
+
+
+.global hook_EnOsnCheckSoHExtData
+hook_EnOsnCheckSoHExtData:
+    push {r0-r12, lr}
+    mov r0,#0x69
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    bx lr
+
+.global hook_EnMa4ExtDataCheckOne
+hook_EnMa4ExtDataCheckOne:
+    push {r0-r12, lr}
+    mov r0,#0x69
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x1 @bne check.
+    pop {r0-r12,lr}
+    bx lr
+
+.global hook_EnMa4ExtDataCheckThree
+hook_EnMa4ExtDataCheckThree:
+    push {r0-r12, lr}
+    mov r0,#0x69
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x0 @bneq check.
+    pop {r0-r12,lr}
+    bx lr
+
+.global hook_EnMa4ExtDataCheckTwo
+hook_EnMa4ExtDataCheckTwo:
+    push {r0-r12, lr}
+    mov r0,#0x69
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x1 @bne check.
+    pop {r0-r12,lr}
+    bx lr
+
+.global hook_EnMnkSongOverride
+hook_EnMnkSongOverride:
+    push {r0-r12,lr}
+    mov r0,#0x61
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x0
+    pop {r0-r12, lr}
+    beq noOverrideSonataItemID
+    b 0x325D5C @Item was already given, so basically noop this call.
+noOverrideSonataItemID:
+    cpy r0,r5
+    bl 0x233BEC
+    b 0x325D5C
+
+.global hook_RemoveSoSCheckKaepora
+hook_RemoveSoSCheckKaepora:
+    push {r0-r12, lr}
+    mov r0,#0x6A
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    bx lr
+
+.global hook_EnGkCheckLullabyRewardGiven
+hook_EnGkCheckLullabyRewardGiven:
+    push {r0-r12,lr}
+    mov r0, #0x62
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    bx lr
+
+.global hook_EnGkCheckLullabyRewardGivenTwo
+hook_EnGkCheckLullabyRewardGivenTwo:
+    push {r0-r12,lr}
+    mov r0, #0x62
+    bl ItemOverride_ReceivedSongOverride
+    cmp r0,#0x1 @We want to check if given, instead of not given at this instruction.
+    pop {r0-r12,lr}
+    bx lr
+
+.global hook_EnMkNWBNOverride
+hook_EnMkNWBNOverride:
+    push {r0-r12,lr}
+    cpy r2,r1
+    mov r1,#0xFF
+    bl ItemOverride_GetSoHOrSongItem
+    ldr r5,.rActiveItemRow_addr
+    ldr r5,[r5]
+    cmp r5,#0x0
+    pop {r0-r12, lr}
+    beq noOverrideNWBNItemID
+    push {r0-r12, lr}
+    ldr r0, [r8,#0xDC] @Load player actor.
+    bl ItemOverride_GetItemTextAndItemID
+    pop {r0-r12, lr}
+    cpy r0,r8
+    b 0x587230
+noOverrideNWBNItemID:
+    cpy r0,r8
+    nop
+    nop
+    bl 0x233BEC
+    b 0x587230

--- a/code/source/asm/songsanity_patches.s
+++ b/code/source/asm/songsanity_patches.s
@@ -1,0 +1,67 @@
+.arm
+
+.section .patch_CheckExtForSongOfTime
+.global patch_CheckExtForSongOfTime
+patch_CheckExtForSongOfTime:
+    bl hook_CheckExtForSongOfTime
+
+.section .patch_SongOfTimeCheckExtData
+.global patch_SongOfTimeCheckExtData
+patch_SongOfTimeCheckExtData:
+    bl hook_SongOfTimeCheckExtData
+
+.section .patch_LullabyIntroCheckEnJg
+.global patch_LullabyIntroCheckEnJg
+patch_LullabyIntroCheckEnJg:
+    bl hook_LullabyIntroCheckEnJg
+
+.section .patch_LullabyCheckEnJg
+.global patch_LullabyCheckEnJg
+patch_LullabyCheckEnJg:
+    bl hook_LullabyCheckEnJg
+
+.section .patch_EnOsnCheckSoHExtData
+.global patch_EnOsnCheckSoHExtData
+patch_EnOsnCheckSoHExtData:
+    bl hook_EnOsnCheckSoHExtData
+
+.section .patch_EnMa4ExtDataCheckOne
+.global patch_EnMa4ExtDataCheckOne
+patch_EnMa4ExtDataCheckOne:
+    bl hook_EnMa4ExtDataCheckOne
+
+.section .patch_EnMa4ExtDataCheckThree
+.global patch_EnMa4ExtDataCheckThree
+patch_EnMa4ExtDataCheckThree:
+    bl hook_EnMa4ExtDataCheckThree
+
+.section .patch_EnMa4ExtDataCheckTwo
+.global patch_EnMa4ExtDataCheckTwo
+patch_EnMa4ExtDataCheckTwo:
+    bl hook_EnMa4ExtDataCheckTwo
+
+.section .patch_EnMnkSongOverride
+.global patch_EnMnkSongOverride
+patch_EnMnkSongOverride:
+    b hook_EnMnkSongOverride
+
+.section .patch_RemoveSoSCheckKaepora
+.global patch_RemoveSoSCheckKaepora
+patch_RemoveSoSCheckKaepora:
+    bl hook_RemoveSoSCheckKaepora
+
+.section .patch_EnGkCheckLullabyRewardGivenOne
+.global patch_EnGkCheckLullabyRewardGivenOne
+patch_EnGkCheckLullabyRewardGivenOne:
+    bleq hook_EnGkCheckLullabyRewardGiven
+
+.section .patch_EnGkCheckLullabyRewardGivenTwo
+.global patch_EnGkCheckLullabyRewardGivenTwo
+patch_EnGkCheckLullabyRewardGivenTwo:
+    bleq hook_EnGkCheckLullabyRewardGivenTwo
+
+
+.section .patch_EnMkNWBNOverride
+.global patch_EnMkNWBNOverride
+patch_EnMkNWBNOverride:
+    b hook_EnMkNWBNOverride

--- a/code/source/game/items.cpp
+++ b/code/source/game/items.cpp
@@ -792,7 +792,7 @@ namespace game {
     const auto mode = get_item_usability_mode(gctx);
 
     // Riding or Honey & Darling minigame (and more?)
-    if (player->flags1.IsSet(act::Player::Flag1::Riding) || cdata.save.anonymous_72 & 1 ||
+    if (player->flags1.IsSet(act::Player::Flag1::Riding) || cdata.save.week_event_reg_09.WEEKEVENTREG_09_01 == 1 ||
         (!(cdata.save.anonymous_13 & 2) && gctx->field_C531 >= 2)) {
       return false;
     }
@@ -811,10 +811,10 @@ namespace game {
     if (cdata.save.anonymous_13 & 2)
       return false;
 
-    if (cdata.save.gossip_stone_give_heartpiece_bitflag & 0x20)
+    if (cdata.save.week_event_reg_90.WEEKEVENTREG_90_20 == 1)
       return false;
 
-    if (cdata.save.anonymous_130 & 8)
+    if (cdata.save.week_event_reg_82.WEEKEVENTREG_82_08 == 1)
       return false;
 
     // Cutscene map

--- a/code/source/game/player.cpp
+++ b/code/source/game/player.cpp
@@ -44,8 +44,8 @@ namespace game::act {
 
     if (active_form == Player::Form::Deku) {
       // Playing the Honey and Darling shooting minigame as Deku Link.
-      info.can_use =
-          cdata.save.player.magic >= 2 || ((cdata.save.anonymous_72 & 1) && gctx->scene == SceneId::HoneyAndDarling);
+      info.can_use = cdata.save.player.magic >= 2 ||
+                     ((cdata.save.week_event_reg_09.WEEKEVENTREG_09_01 == 1) && gctx->scene == SceneId::HoneyAndDarling);
     } else {
       info.can_use = flags3.IsSet(Flag3::DekuStuffMaybe) || (cdata.field_3696 == 1 && gctx->hud_state.field_244) ||
                      gctx->field_C531 || rnd::util::GetPointer<bool(ItemId)>(0x224EF8)(info.item_id);

--- a/code/source/game/player.cpp
+++ b/code/source/game/player.cpp
@@ -44,8 +44,8 @@ namespace game::act {
 
     if (active_form == Player::Form::Deku) {
       // Playing the Honey and Darling shooting minigame as Deku Link.
-      info.can_use = cdata.save.player.magic >= 2 ||
-                     ((cdata.save.week_event_reg_09.WEEKEVENTREG_09_01 == 1) && gctx->scene == SceneId::HoneyAndDarling);
+      info.can_use = cdata.save.player.magic >= 2 || ((cdata.save.week_event_reg_09.WEEKEVENTREG_09_01 == 1) &&
+                                                      gctx->scene == SceneId::HoneyAndDarling);
     } else {
       info.can_use = flags3.IsSet(Flag3::DekuStuffMaybe) || (cdata.field_3696 == 1 && gctx->hud_state.field_244) ||
                      gctx->field_C531 || rnd::util::GetPointer<bool(ItemId)>(0x224EF8)(info.item_id);

--- a/code/source/game/player.cpp
+++ b/code/source/game/player.cpp
@@ -92,7 +92,7 @@ namespace game::act {
           !statue || (statue->pos.pos.x == player->pos.pos.x && statue->pos.pos.y == player->pos.pos.y &&
                       statue->pos.pos.z == player->pos.pos.z);
       if (player->timer > 135 || statue_ready) {
-        gctx->ocarina_state = OcarinaState::StoppedPlaying;
+        gctx->msg_context.ocarina_state = OcarinaState::StoppedPlaying;
         PlayerChangeStateToStill(player, gctx);
       } else if (statue && !statue_ready) {
         // Speed up the statue fadeout. (0x18 + 8 = 0x20 per game tick)

--- a/code/source/rnd/gfx.cpp
+++ b/code/source/rnd/gfx.cpp
@@ -15,6 +15,7 @@ namespace rnd {
   static u64 lastTick = 0;
   static u64 ticksElapsed = 0;
   static bool isAsleep = false;
+  static s64 playingOnCitra = 0;
   DungeonInfo rDungeonInfoData[10];
 
   u32 pressed;
@@ -624,9 +625,8 @@ namespace rnd {
   static void Gfx_ShowMenu(void) {
     pressed = 0;
     Draw_ClearFramebuffer();
-    if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+    if (!playingOnCitra)
       Draw_FlushFramebuffer();
-    }
     do {
       // End the loop if the system has gone to sleep, so the game can properly respond
       if (isAsleep) {
@@ -717,9 +717,8 @@ namespace rnd {
           showingLegend = false;
           Draw_ClearBackbuffer();
           Draw_CopyBackBuffer();
-          if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+          if (!playingOnCitra)
             Draw_FlushFramebuffer();
-          }
           break;
         } else if (pressed & BUTTON_R1) {
           showingLegend = false;
@@ -753,15 +752,15 @@ namespace rnd {
       Gfx_DrawButtonPrompts();
       Gfx_DrawHeader();
       Draw_CopyBackBuffer();
-      if (gSettingsContext.playOption == PLAY_ON_CONSOLE) {
+      if (!playingOnCitra)
         Draw_FlushFramebuffer();
-      }
       pressed = Input_WaitWithTimeout(1000, closingButton);
 
     } while (true);
   }
 
   void Gfx_Init(void) {
+    svcGetSystemInfo(&playingOnCitra, 0x20000, 0);
     Draw_SetupFramebuffer();
     Draw_ClearBackbuffer();
 

--- a/code/source/rnd/input.cpp
+++ b/code/source/rnd/input.cpp
@@ -1,5 +1,6 @@
 #include "rnd/input.h"
 #include "common/debug.h"
+#include "game/pad.h"
 #include "hid.h"
 #include "utils.h"
 #include "z3d/z3DVec.h"
@@ -21,6 +22,7 @@ namespace rnd {
     rInputCtx.pressed.val = (rInputCtx.cur.val) & (~rInputCtx.old.val);
     rInputCtx.up.val = (~rInputCtx.cur.val) & (rInputCtx.old.val);
     rInputCtx.old.val = rInputCtx.cur.val;
+    rInputCtx.cp_curr = real_hid->pad.pads[real_hid->pad.index].cp;
   }
 
   u32 buttonCheck(u32 key) {

--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -91,7 +91,7 @@ namespace rnd {
   }
 
   void ItemEffect_GiveGreatSpin(game::CommonData* comData, s16 arg1, s16 arg2) {
-    comData->save.has_great_spin_0x02 = 2;
+    comData->save.week_event_reg_23.WEEKEVENTREG_RECEIVED_GREAT_SPIN_ATTACK = 1;
   }
 
   void ItemEffect_GiveDoubleMagic(game::CommonData* comData, s16 arg1, s16 arg2) {

--- a/code/source/rnd/item_effect.cpp
+++ b/code/source/rnd/item_effect.cpp
@@ -149,7 +149,6 @@ namespace rnd {
       comData->save.inventory.collect_register.sonata_of_awakening = 1;
       break;
     case 2:
-      comData->save.inventory.collect_register.lullaby_intro = 1;
       comData->save.inventory.collect_register.goron_lullaby = 1;
       break;
     case 3:

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -43,6 +43,8 @@ namespace rnd {
                                    0x2D, 0x33, 0x37, 0x3B, 0x3F, 0x42, 0x46, 0x4A, 0x4F, 0x53,
                                    0x57, 0x59, 0x5D, 0x61, 0x65, 0x69, 0x6D, 0x73, 0x77, 0x7B};
 
+  static bool givenItemOverride = false;
+
   void ItemOverride_Init(void) {
 #ifdef ENABLE_DEBUG
     // Manual overide example code
@@ -633,6 +635,46 @@ namespace rnd {
             (itemToBeGiven->itemId > 0x49 && itemToBeGiven->itemId < 0x81) || override.value.getItemId == 0x5A);
   }
 
+  GetItemID ItemOverride_MapSongsToGID(game::ItemId incomingItemId) {
+    switch (incomingItemId) {
+    case game::ItemId::SonataOfAwakening:
+      gExtSaveData.givenSongChecks.sonataGiven = 1;
+      return GetItemID(0x4B);
+    case game::ItemId::GoronLullaby:
+      gExtSaveData.givenSongChecks.goronLullabyGiven = 2;
+      return GetItemID(0x4D);
+    case game::ItemId::NewWaveBossaNova:
+      gExtSaveData.givenSongChecks.newWaveBossaNovaGiven = 1;
+      return GetItemID(0x4E);
+    case game::ItemId::ElegyOfEmptiness:
+      gExtSaveData.givenSongChecks.elegyOfEmptinessGiven = 1;
+      return GetItemID(0x4F);
+    case game::ItemId::OathToOrder:
+      gExtSaveData.givenSongChecks.oathToOrderGiven = 1;
+      return GetItemID(0x51);
+    case game::ItemId::SongOfTime:
+      gExtSaveData.givenSongChecks.songOfTimeGiven = 1;
+      return GetItemID(0x53);
+    case game::ItemId::SongOfHealing:
+      gExtSaveData.givenSongChecks.songOfHealingGiven = 1;
+      return GetItemID(0x54);
+    case game::ItemId::EponaSong:
+      gExtSaveData.givenSongChecks.eponasSongGiven = 1;
+      return GetItemID(0x6C);
+    case game::ItemId::SongOfSoaring:
+      gExtSaveData.givenSongChecks.songOfSoaringGiven = 1;
+      return GetItemID(0x72);
+    case game::ItemId::SongOfStorms:
+      gExtSaveData.givenSongChecks.songOfStormsGiven = 1;
+      return GetItemID(0x73);
+    case game::ItemId::GoronLullabyIntro:
+      gExtSaveData.givenSongChecks.goronLullabyGiven = 1;
+      return GetItemID(0x74);
+    default:
+      return GetItemID::GI_NONE;
+    }
+  }
+
   extern "C" {
   bool ItemOverride_CheckAromaGivenItem() {
     if (gExtSaveData.givenItemChecks.enAlGivenItem > 0)
@@ -829,11 +871,20 @@ namespace rnd {
     }
     if (incomingGetItemId != 0x44 && incomingGetItemId != 0x6D && incomingGetItemId != 0x52)
       player->get_item_id = incomingNegative ? -baseItemId : baseItemId;
-    // Weird edge case with the way text and masks are handled with Couples' Mask.
-    // Set the text and apply it later in a different patch.
-    if (incomingGetItemId == 0x85) {
+      // Edge case with Song of healing items. Override their show text in their own functions
+      // to ensure that we have the same 'feel' as the base game.
+      // This also ensures that if there is no override the default text still works.
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: %#04x\n", __func__, incomingGetItemId);
+#endif
+    if (incomingGetItemId == 0x4B || incomingGetItemId == 0x4D || incomingGetItemId == 0x4E ||
+        incomingGetItemId == 0x51 || incomingGetItemId == 0x53 || incomingGetItemId == 0x6C ||
+        (incomingGetItemId <= 0x72 || incomingGetItemId >= 0x74) ||
+        (incomingGetItemId >= 0x78 && incomingGetItemId <= 0x7A) || incomingGetItemId == 0x85 ||
+        incomingGetItemId == 0x87) {
       rStoredTextId = rActiveItemRow->textId;
     }
+    givenItemOverride = true;
     return;
   }
 
@@ -870,10 +921,13 @@ namespace rnd {
     }
   }
 
-  void ItemOverride_GetSoHItem(game::GlobalContext* gctx, game::act::Actor* fromActor, s16 incomingItemId) {
+  void ItemOverride_GetSoHOrSongItem(game::GlobalContext* gctx, game::act::Actor* fromActor, s16 incomingItemId) {
     game::act::Player* link = gctx->GetPlayerActor();
-    // Run only once. Once the get item is assigned, we shouldn't have to worry about running it again.
-    // This is mainly prevalent when the item override is in a calc function (Anju & Kafei).
+// Run only once. Once the get item is assigned, we shouldn't have to worry about running it again.
+// This is mainly prevalent when the item override is in a calc function (Anju & Kafei).
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Link's getitemid %#04x incoming GID is %#04x\n", __func__, link->get_item_id, incomingItemId);
+#endif
     if (link->get_item_id != 0x00)
       return;
     if (incomingItemId == 0x7A) {
@@ -885,12 +939,16 @@ namespace rnd {
     } else if (incomingItemId == 0x78) {
       gExtSaveData.givenItemChecks.enOsnGivenMask = 1;
     } else if (incomingItemId == 0x50) {
-      fromActor = gctx->GetPlayerActor();
+      fromActor = link;
     } else if (incomingItemId == 0x85) {
       gExtSaveData.givenItemChecks.kafeiGivenItem = 1;
+    } else if ((incomingItemId >= 0x61 || incomingItemId <= 0x6C) || incomingItemId == 0x73) {
+      // Additional logic to map songs to getItemIds.
+      incomingItemId = (s16)ItemOverride_MapSongsToGID(game::ItemId(incomingItemId));
+      fromActor = link;
     }
 
-    ItemOverride_GetItem(gctx, fromActor, gctx->GetPlayerActor(), incomingItemId);
+    ItemOverride_GetItem(gctx, fromActor, link, incomingItemId);
     return;
   }
 
@@ -998,15 +1056,22 @@ namespace rnd {
   }
 
   // clang-format on
-  void ItemOverride_SwapSoHGetItemText(game::GlobalContext* gctx, u16 textId, game::act::Actor* fromActor) {
-    // Check which text ID is coming in. If it's any mask from Song of Healing, replace it with active item text.
-    if (textId == 0x79 || textId == 0x7a || textId == 0x87 || textId == 0x78) {
-      return;
-    } else if (textId == 0x85) {
-      gctx->ShowMessage(rStoredTextId);
-      rStoredTextId = 0;
-    } else
+  void ItemOverride_SwapSoHAndSongGetItemText(game::GlobalContext* gctx, u16 textId, game::act::Actor* fromActor) {
+// Check which text ID is coming in. If it's any mask from Song of Healing, replace it with active item text.
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: txtId = %#08x\n", __func__, textId);
+#endif
+    if (givenItemOverride) {
+      givenItemOverride = false;
+      if (rStoredTextId) {
+        gctx->ShowMessage(rStoredTextId);
+        rStoredTextId = 0;
+      } else
+        gctx->ShowMessage(textId);
+    } else {
       gctx->ShowMessage(textId);
+    }
+
     return;
   }
 
@@ -1130,6 +1195,50 @@ namespace rnd {
 
   u8 ItemOverride_ReceivedOcarinaFromSkt() {
     return gExtSaveData.givenItemChecks.ocarinaOfTimeGiven == 1 ? 1 : 0;
+  }
+
+  u8 ItemOverride_ReceivedSongOverride(s16 incomingItemId) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Incoming item id is %#04x\n", __func__, incomingItemId);
+#endif
+    game::OcarinaSong lastPlayedSong = GetContext().gctx->msg_context.lastPlayedSong;
+    switch (incomingItemId) {
+    case 0x61:
+      return gExtSaveData.givenSongChecks.sonataGiven == 1 ? 1 : 0;
+    case 0x62:
+      if (lastPlayedSong != game::OcarinaSong::GoronLullablyIntro || lastPlayedSong != game::OcarinaSong::GoronLullaby)
+        return gExtSaveData.givenSongChecks.goronLullabyGiven == 1 ? 1 : 0;
+      else
+        return 1;
+      break;
+    case 0x63:
+      return gExtSaveData.givenSongChecks.newWaveBossaNovaGiven == 1 ? 1 : 0;
+    case 0x64:
+      return gExtSaveData.givenSongChecks.elegyOfEmptinessGiven == 1 ? 1 : 0;
+    case 0x65:
+      return gExtSaveData.givenSongChecks.oathToOrderGiven == 1 ? 1 : 0;
+    case 0x67:
+      return gExtSaveData.givenSongChecks.songOfTimeGiven == 1 ? 1 : 0;
+    case 0x68:
+      return gExtSaveData.givenSongChecks.songOfHealingGiven == 1 ? 1 : 0;
+    case 0x69:
+      return gExtSaveData.givenSongChecks.eponasSongGiven == 1 ? 1 : 0;
+    case 0x6A:
+      return gExtSaveData.givenSongChecks.songOfSoaringGiven == 1 ? 1 : 0;
+    case 0x6B:
+      return gExtSaveData.givenSongChecks.songOfStormsGiven == 1 ? 1 : 0;
+    case 0x73:
+      return gExtSaveData.givenSongChecks.goronLullabyIntroGiven == 1 ? 1 : 0;
+    default:
+      return 0;
+    }
+  }
+
+  u8 ItemOverride_CheckIfSongOfTimeAwarded(u8 currentItem) {
+    game::SceneId scene = GetContext().gctx->scene;
+    if (scene == game::SceneId::ClockTowerRooftop && gExtSaveData.givenSongChecks.songOfTimeGiven == 0)
+      return 0x4C;
+    return currentItem;
   }
   }
 }  // namespace rnd

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -557,27 +557,27 @@ namespace rnd {
     game::SaveData& saveData = game::GetCommonData().save;
     switch (getItemMapId) {
     case 0xB4:
+      saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_CLOCK_TOWN = 1;
       util::GetPointer<void(u8)>(0x548260)(0x0);
-      saveData.overworld_map_get_flags_0x3F_for_all = saveData.overworld_map_get_flags_0x3F_for_all | 1;
       break;
     case 0xB5:
+      saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_WOODFALL = 1;
       util::GetPointer<void(u8)>(0x548260)(0x1);
-      saveData.overworld_map_get_flags_0x3F_for_all = saveData.overworld_map_get_flags_0x3F_for_all | 2;
       break;
     case 0xB6:
-      saveData.overworld_map_get_flags_0x3F_for_all = saveData.overworld_map_get_flags_0x3F_for_all | 4;
+      saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_SNOWHEAD = 1;
       util::GetPointer<void(u8)>(0x548260)(0x2);
       break;
     case 0xB7:
-      saveData.overworld_map_get_flags_0x3F_for_all = saveData.overworld_map_get_flags_0x3F_for_all | 8;
+      saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_ROMANI_RANCH = 1;
       util::GetPointer<void(u8)>(0x548260)(0x3);
       break;
     case 0xB8:
-      saveData.overworld_map_get_flags_0x3F_for_all = saveData.overworld_map_get_flags_0x3F_for_all | 0x10;
+      saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_GREAT_BAY = 1;
       util::GetPointer<void(u8)>(0x548260)(0x4);
       break;
     case 0xB9:
-      saveData.overworld_map_get_flags_0x3F_for_all = saveData.overworld_map_get_flags_0x3F_for_all | 0x20;
+      saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_STONE_TOWER = 1;
       util::GetPointer<void(u8)>(0x548260)(0x5);
       break;
     default:

--- a/code/source/rnd/objects.cpp
+++ b/code/source/rnd/objects.cpp
@@ -72,9 +72,9 @@ namespace rnd {
 
   extern "C" game::ActorResource::ActorResource* ExtendedObject_GetStatus() {
     s32 i;
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: rStoredObjId is %#06x\n", __func__, rStoredObjId);
-#endif
+    // #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    //     rnd::util::Print("%s: rStoredObjId is %#06x\n", __func__, rStoredObjId);
+    // #endif
     for (i = 0; i < rExtendedObjectCtx.num; ++i) {
       s32 id = rExtendedObjectCtx.status[i].object_id;
       id = (id < 0 ? -id : id);

--- a/code/source/rnd/ocarina.cpp
+++ b/code/source/rnd/ocarina.cpp
@@ -24,7 +24,7 @@ namespace rnd {
 
     // Disable BGM fadeout
     util::Write(gctx, 0x8422, 1);
-    gctx->ocarina_state = game::OcarinaState::StoppedPlaying;
+    gctx->msg_context.ocarina_state = game::OcarinaState::StoppedPlaying;
   }
 
   static bool IsElegyOfEmptinessAllowed() {
@@ -70,8 +70,8 @@ namespace rnd {
       EndOcarinaSession(self);
       auto* gctx = GetContext().gctx;
       game::sound::PlayEffect(game::sound::EffectId::NA_SE_SY_TRE_BOX_APPEAR);
-      gctx->ocarina_song = song;
-      gctx->ocarina_state = game::OcarinaState::PlayingAndReplayDone;
+      gctx->msg_context.ocarina_song = song;
+      gctx->msg_context.ocarina_state = game::OcarinaState::PlayingAndReplayDone;
       self->song = u16(song);
       // This flag must always be false; otherwise the Song of Soaring handler will refuse
       // to show the map screen.
@@ -93,11 +93,11 @@ namespace rnd {
       auto* gctx = GetContext().gctx;
       if (IsElegyOfEmptinessAllowed()) {
         game::sound::PlayEffect(game::sound::EffectId::NA_SE_SY_TRE_BOX_APPEAR);
-        gctx->ocarina_song = game::OcarinaSong::ElegyOfEmptiness;
-        gctx->ocarina_state = game::OcarinaState::PlayingAndReplayDone;
+        gctx->msg_context.ocarina_song = game::OcarinaSong::ElegyOfEmptiness;
+        gctx->msg_context.ocarina_state = game::OcarinaState::PlayingAndReplayDone;
       } else {
         gctx->ShowMessage(0x1B95, 0);  // "Your notes echoed far..."
-        gctx->ocarina_state = game::OcarinaState::StoppedPlaying;
+        gctx->msg_context.ocarina_state = game::OcarinaState::StoppedPlaying;
         util::GetPointer<void(int)>(0x1D8C5C)(0);
       }
 

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -90,11 +90,11 @@ namespace rnd {
     saveData.player.magic_size_type = 0;  // saveData.player.magic = 10;
     saveData.player.magic_num_upgrades = 0;
     saveData.equipment.data[3].item_btns[0] = game::ItemId::DekuNuts;
-    saveData.inventory.item_counts[6] = 50;   // Arrows
-    saveData.inventory.item_counts[11] = 40;  // Bombs
-    saveData.inventory.item_counts[12] = 40;  // Bombchus
-    saveData.inventory.item_counts[14] = 30;  // Nuts
-    saveData.inventory.item_counts[13] = 20;  // Sticks
+    saveData.inventory.item_counts[6] = 50;                                  // Arrows
+    saveData.inventory.item_counts[11] = 40;                                 // Bombs
+    saveData.inventory.item_counts[12] = 40;                                 // Bombchus
+    saveData.inventory.item_counts[14] = 30;                                 // Nuts
+    saveData.inventory.item_counts[13] = 20;                                 // Sticks
     saveData.week_event_reg_23.WEEKEVENTREG_RECEIVED_GREAT_SPIN_ATTACK = 1;  // Set great spin.
 
     saveData.player.owl_statue_flags.great_bay = 1;
@@ -180,7 +180,8 @@ namespace rnd {
   void SaveFile_SkipMinorCutscenes() {
     game::SaveData& saveData = game::GetCommonData().save;
     saveData.has_completed_intro = 0x2B;
-    saveData.week_event_reg_58.WEEKEVENTREG_TALKED_GORON_SHOPKEEPER_AS_NON_GORON = 1;
+    saveData.week_event_reg_59.WEEKEVENTREG_59_04 = 1;
+    saveData.week_event_reg_31.WEEKEVENTREG_TATL_NOT_FINISHED_MOUNTAIN_TEXT = 1;
 
     // camera panning cutscenes
     saveData.week_event_reg_00.WEEKEVENTREG_ENTERED_TERMINA_FIELD = 1;
@@ -202,14 +203,14 @@ namespace rnd {
     saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_NORTH_CLOCK_TOWN = 1;
     saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE = 1;
     saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_SNOWHEAD_TEMPLE = 1;
-    saveData.week_event_reg_130.WEEKEVENTREG_DEKU_THRONE_ROOM_CAMERA_PAN = 1;
+    saveData.week_event_reg_131.WEEKEVENTREG_DEKU_THRONE_ROOM_CAMERA_PAN = 1;
     saveData.week_event_reg_136.WEEKEVENTREG_CAMERA_PAN_WOODFALL_ENTER = 1;
     saveData.snowhead_temple_main_room_camera_pan_0x01 = 0x01;
     saveData.pirates_fortress_exterior_camera_pan_0x04 = 0x04;
     saveData.ikana_castle_camera_pan_0x08 = 0x80;
 
     // Tatl constant tatling skip
-    saveData.week_event_reg_130.WEEKEVENTREG_TATL_MOON_TEAR_DIALOGUE = 1;
+    saveData.week_event_reg_131.WEEKEVENTREG_TATL_MOON_TEAR_DIALOGUE = 1;
     saveData.week_event_reg_31.WEEKEVENTREG_TATL_GO_SOUTH_TEXT = 1;
     saveData.week_event_reg_87.WEEKEVENTREG_TATL_GO_NORTH_DIALOGUE_SPOKEN = 1;
     saveData.week_event_reg_87.WEEKEVENTREG_TATL_GO_WEST_DIALOGUE_SPOKEN = 1;
@@ -222,12 +223,12 @@ namespace rnd {
     saveData.talt_dialogue_great_bay_temple.whirlpool_room_tatl_dialogue = 1;
 
     // tutorials
-    // saveData.week_event_reg_130.WEEKEVENTREG_SKIP_MAP_TUTORIAL_BY_TINGLE = 1;
+    // saveData.week_event_reg_131.WEEKEVENTREG_SKIP_MAP_TUTORIAL_BY_TINGLE = 1;
 
     // Misc cutscenes
     saveData.meeting_happy_mask_salesman_0x01 = 0x01;
     saveData.skullkid_backstory_cutscene_0x10 = 0x10;
-    saveData.week_event_reg_130.WEEKEVENTREG_OWL_STATUE_CUTSCENE = 1;
+    saveData.week_event_reg_131.WEEKEVENTREG_OWL_STATUE_CUTSCENE = 1;
     // saveData.dungeon_skip_portal_cutscene_0x3C_to_skip_all = 0x3C;
 
     // Needs to be greater than zero to skip first time song of time cutscene
@@ -247,7 +248,6 @@ namespace rnd {
     saveData.week_event_reg_137.WEEKEVENTREG_GREAT_BAY_TEMPLE_OPENED = 1;
     // Misc
     saveData.week_event_reg_137.WEEKEVENTREG_DEKU_FLOWN_IN = 1;
-
   }
 
   void SaveFile_SetStartingOwlStatues() {

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -33,6 +33,7 @@ namespace rnd {
     saveData.inventory.inventory_count_register.stick_upgrades = 2;
     saveData.inventory.inventory_count_register.nut_upgrade = 2;
     saveData.player.rupee_count = 5000;
+    rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::Ocarina);
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::Arrow);
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::IceArrow);
     rnd::util::GetPointer<void(game::ItemId)>(0x22b14c)(game::ItemId::LightArrow);
@@ -108,12 +109,12 @@ namespace rnd {
     saveData.player.owl_statue_flags.ikana_canyon = 1;
     saveData.player.owl_statue_flags.stone_tower = 1;
 
-    saveData.inventory.collect_register.sonata_of_awakening = 1;
+    // saveData.inventory.collect_register.sonata_of_awakening = 1;
     saveData.inventory.collect_register.goron_lullaby = 1;
-    saveData.inventory.collect_register.new_wave_bossa_nova = 1;
+    // saveData.inventory.collect_register.new_wave_bossa_nova = 1;
     saveData.inventory.collect_register.elegy_of_emptiness = 1;
     saveData.inventory.collect_register.eponas_song = 1;
-    saveData.inventory.collect_register.song_of_soaring = 1;
+    // saveData.inventory.collect_register.song_of_soaring = 1;
     saveData.inventory.collect_register.song_of_time = 1;
     // saveData.inventory.collect_register.oath_to_order = 1;
     // saveData.inventory.collect_register.song_of_healing = 1;

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -95,7 +95,7 @@ namespace rnd {
     saveData.inventory.item_counts[12] = 40;  // Bombchus
     saveData.inventory.item_counts[14] = 30;  // Nuts
     saveData.inventory.item_counts[13] = 20;  // Sticks
-    saveData.has_great_spin_0x02 = 2;         // Set great spin.
+    saveData.week_event_reg_23.WEEKEVENTREG_RECEIVED_GREAT_SPIN_ATTACK = 1;  // Set great spin.
 
     saveData.player.owl_statue_flags.great_bay = 1;
     saveData.player.owl_statue_flags.zora_cape = 1;
@@ -120,7 +120,10 @@ namespace rnd {
 
     gSettingsContext.skipBombersMinigame = 1;
     gSettingsContext.freeScarecrow = 1;
-    saveData.activate_dungeon_skip_portal_0xF0_for_all = 0xF0;
+    saveData.week_event_reg_132.WEEKEVENTREG_SKIP_WOODFALL_PORTAL_CUTSCENE = 1;
+    saveData.week_event_reg_132.WEEKEVENTREG_SKIP_SNOWHEAD_PORTAL_CUTSCENE = 1;
+    saveData.week_event_reg_132.WEEKEVENTREGSKIP_GREAT_BAY_PORTAL_CUTSCENE = 1;
+    saveData.week_event_reg_132.WEEKEVENTREG_SKIP_STT_PORTAL_CUTSCENE = 1;
     // SaveFile_FillOverWorldMapData();
     saveData.inventory.collect_register.oath_to_order = 1;
 
@@ -162,11 +165,11 @@ namespace rnd {
       SaveFile_SetStartingInventory();
 
       // These events replay after song of time
-      saveData.ct_guard_allows_through_if_0x20 = 0x20;
+      saveData.week_event_reg_12.WEEKEVENTREG_12_20 = 1;
       saveData.tatl_dialogue_snowhead_entry_0x08 = 0x08;
       saveData.pirate_leader_dialogue_0x20 = 0x20;
-      saveData.clock_town_temp_flags.ct_deku_in_flower_if_present = 1;
-      saveData.skip_tingle_intro_dialogue_0x01 = 0x01;
+      saveData.week_event_reg_73.WEEKEVENTREG_73_04 = 1;
+      saveData.week_event_reg_10.WEEKEVENTREG_TALKED_TINGLE = 1;
 
       saveData.player_form = game::act::Player::Form::Human;
       // Shuffling now works, removing the starting item with notebook.
@@ -177,61 +180,55 @@ namespace rnd {
   void SaveFile_SkipMinorCutscenes() {
     game::SaveData& saveData = game::GetCommonData().save;
     saveData.has_completed_intro = 0x2B;
-    saveData.skip_tatl_talking_0x04 = 0x04;
+    saveData.week_event_reg_58.WEEKEVENTREG_TALKED_GORON_SHOPKEEPER_AS_NON_GORON = 1;
 
     // camera panning cutscenes
-    saveData.camera_panning_event_flag_bundle.termina_field = 1;
-    saveData.camera_panning_event_flag_bundle.graveyard = 1;
-    saveData.camera_panning_event_flag_bundle.romani_ranch = 1;
-    saveData.camera_panning_event_flag_bundle.gorman_track = 1;
-    saveData.camera_panning_event_flag_bundle.mountain_village = 1;
-    saveData.camera_panning_event_flag_bundle.goron_city = 1;
-    saveData.camera_panning_event_flag_bundle.snowhead = 1;
-    saveData.camera_panning_event_flag_bundle.southern_swamp = 1;
-    saveData.camera_panning_event_flag_bundle.woodfall = 1;
-    saveData.camera_panning_event_flag_bundle.deku_palace = 1;
-    saveData.camera_panning_event_flag_bundle.great_bay_coast = 1;
-    saveData.camera_panning_event_flag_bundle.pirates_fortress_interior = 1;
-    saveData.camera_panning_event_flag_bundle.zora_domain = 1;
-    saveData.camera_panning_event_flag_bundle.waterfall_rapids = 1;
-    saveData.camera_panning_event_flag_bundle.ikana_canyon = 1;
-    saveData.camera_panning_event_flag_bundle.stone_tower = 1;
-    saveData.camera_panning_event_flag_bundle.stone_tower_inverted = 1;
-    saveData.camera_panning_event_flag_bundle.east_clock_town = 1;
-    saveData.camera_panning_event_flag_bundle.west_clock_town = 1;
-    saveData.camera_panning_event_flag_bundle.north_clock_town = 1;
-    saveData.camera_panning_event_flag_bundle.woodfall_temple = 1;
-    saveData.camera_panning_event_flag_bundle.snowhead_temple_entry_room = 1;
-    saveData.camera_panning_event_flag_bundle.stone_tower_temple = 1;
-    saveData.camera_panning_event_flag_bundle.stone_tower_temple_inverted = 1;
-    saveData.cut_scene_flag_bundle.deku_palace_throne_room_camera_pan = 1;
-    saveData.road_to_woodfall_camera_pan_0x08 = 0x08;
+    saveData.week_event_reg_00.WEEKEVENTREG_ENTERED_TERMINA_FIELD = 1;
+    saveData.week_event_reg_00.WEEKEVENTREG_ENTERED_IKANA_GRAVEYARD = 1;
+    saveData.week_event_reg_00.WEEKEVENTREG_ENTERED_ROMANI_RANCH = 1;
+    saveData.week_event_reg_00.WEEKEVENTREG_ENTERED_GORMAN_TRACK = 1;
+    saveData.week_event_reg_00.WEEKEVENTREG_ENTERED_MOUNTAIN_VILLAGE_WINTER = 1;
+    saveData.week_event_reg_00.WEEKEVENTREG_ENTERED_GORON_SHRINE = 1;
+    saveData.week_event_reg_00.WEEKEVENTREG_ENTERED_SNOWHEAD = 1;
+    saveData.week_event_reg_01.WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE = 1;
+    saveData.week_event_reg_01.WEEKEVENTREG_ENTERED_SNOWHEAD_TEMPLE = 1;
+    saveData.week_event_reg_01.WEEKEVENTREG_ENTERED_GREAT_BAY_TEMPLE = 1;
+    saveData.week_event_reg_01.WEEKEVENTREG_ENTERED_STONE_TOWER_TEMPLE = 1;
+    saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_IKANA_CASTLE = 1;
+    saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_STONE_TOWER = 1;
+    saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_STONE_TOWER_INVERTED = 1;
+    saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_EAST_CLOCK_TOWN = 1;
+    saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_WEST_CLOCK_TOWN = 1;
+    saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_NORTH_CLOCK_TOWN = 1;
+    saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE = 1;
+    saveData.week_event_reg_02.WEEKEVENTREG_ENTERED_SNOWHEAD_TEMPLE = 1;
+    saveData.week_event_reg_130.WEEKEVENTREG_DEKU_THRONE_ROOM_CAMERA_PAN = 1;
+    saveData.week_event_reg_136.WEEKEVENTREG_CAMERA_PAN_WOODFALL_ENTER = 1;
     saveData.snowhead_temple_main_room_camera_pan_0x01 = 0x01;
     saveData.pirates_fortress_exterior_camera_pan_0x04 = 0x04;
     saveData.ikana_castle_camera_pan_0x08 = 0x80;
 
     // Tatl constant tatling skip
-    saveData.cut_scene_flag_bundle.tatl_moon_tear_dialogue = 1;
-    saveData.tatl_dialogue_flags2.go_south = 1;
-    saveData.tatl_dialogue_direction_to_go.go_north = 1;
-    saveData.tatl_dialogue_direction_to_go.go_west = 1;
-    saveData.tatl_dialogue_direction_to_go.go_east = 1;
-    saveData.tatl_dialogue_direction_to_go.go_to_skullkid = 1;
+    saveData.week_event_reg_130.WEEKEVENTREG_TATL_MOON_TEAR_DIALOGUE = 1;
+    saveData.week_event_reg_31.WEEKEVENTREG_TATL_GO_SOUTH_TEXT = 1;
+    saveData.week_event_reg_87.WEEKEVENTREG_TATL_GO_NORTH_DIALOGUE_SPOKEN = 1;
+    saveData.week_event_reg_87.WEEKEVENTREG_TATL_GO_WEST_DIALOGUE_SPOKEN = 1;
+    saveData.week_event_reg_87.WEEKEVENTREG_TATL_GO_EAST_DIALOGUE_SPOKEN = 1;
+    saveData.week_event_reg_87.WEEKEVENTREG_TATL_GO_TO_MOON_DIALOGUE_SPOKEN = 1;
     saveData.woodfall_platform_tatl_dialogue_0x02 = 0x02;
     saveData.tatl_dialogue_inside_woodfall_temple_0x80 = 0x80;
-    saveData.tatl_apology_dialogue_post_Odolwa_0x80 = 0x80;
+    saveData.week_event_reg_07.WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE_PRISON = 1;
     saveData.talt_dialogue_great_bay_temple.waterwheel_room_tatl_dialogue = 1;
     saveData.talt_dialogue_great_bay_temple.whirlpool_room_tatl_dialogue = 1;
 
     // tutorials
-    // saveData.cut_scene_flag_bundle.map_tutorial_by_tingle = 1;
+    // saveData.week_event_reg_130.WEEKEVENTREG_SKIP_MAP_TUTORIAL_BY_TINGLE = 1;
 
     // Misc cutscenes
     saveData.meeting_happy_mask_salesman_0x01 = 0x01;
     saveData.skullkid_backstory_cutscene_0x10 = 0x10;
-    saveData.cut_scene_flag_bundle.owl_statue_cut_scene = 1;
+    saveData.week_event_reg_130.WEEKEVENTREG_OWL_STATUE_CUTSCENE = 1;
     // saveData.dungeon_skip_portal_cutscene_0x3C_to_skip_all = 0x3C;
-    saveData.turtle_flags.skip_swimming_to_great_bay_temple_cutscene = 1;
 
     // Needs to be greater than zero to skip first time song of time cutscene
     saveData.player.three_day_reset_count = 1;
@@ -240,16 +237,17 @@ namespace rnd {
   void SaveFile_SetFastAnimationFlags() {
     game::SaveData& saveData = game::GetCommonData().save;
     // Masks
-    saveData.have_worn_mask_once.has_worn_deku_mask_once = 1;
-    saveData.have_worn_mask_once.has_worn_goron_mask_once = 1;
-    saveData.have_worn_mask_once.has_worn_zora_mask_once = 1;
-    saveData.have_worn_mask_once.has_worn_deity_mask_once = 1;
+    saveData.week_event_reg_30.WEEKEVENTREG_WORN_DEKU_MASK_ONCE = 1;
+    saveData.week_event_reg_30.WEEKEVENTREG_WORN_GORON_MASK_ONCE = 1;
+    saveData.week_event_reg_30.WEEKEVENTREG_WORN_ZORA_MASK_ONCE = 1;
+    saveData.week_event_reg_30.WEEKEVENTREG_WORN_FIERCE_DEITY_MASK_ONCE = 1;
     // Dungeons
-    saveData.opened_temple_once_flags.woodfall_temple_opened_at_least_once = 1;
-    saveData.opened_temple_once_flags.snowhead_temple_opened_at_least_once = 1;
-    saveData.opened_temple_once_flags.greatbay_temple_opened_at_least_once = 1;
+    saveData.week_event_reg_137.WEEKEVENTREG_WOODFALL_TEMPLE_OPENED = 1;
+    saveData.week_event_reg_137.WEEKEVENTREG_SNOWHEAD_TEMPLE_OPENED = 1;
+    saveData.week_event_reg_137.WEEKEVENTREG_GREAT_BAY_TEMPLE_OPENED = 1;
     // Misc
-    saveData.opened_temple_once_flags.deku_flown_in_at_least_once = 1;
+    saveData.week_event_reg_137.WEEKEVENTREG_DEKU_FLOWN_IN = 1;
+
   }
 
   void SaveFile_SetStartingOwlStatues() {
@@ -287,7 +285,7 @@ namespace rnd {
       saveData.bomberscode[2] = 0x03;
       saveData.bomberscode[3] = 0x04;
       saveData.bomberscode[4] = 0x05;
-      saveData.clock_town_temp_flags.bomber_open_hideout = 1;  // Currently gets reset by Song of time
+      saveData.week_event_reg_73.WEEKEVENTREG_73_80 = 1;  // Currently gets reset by Song of time
     }
 
     // Game uses an inventory check to determine whether you can
@@ -308,14 +306,20 @@ namespace rnd {
       // Currently sets song to the ingame default: LLLLLLLL
       saveData.inventory.collect_register.scarecrows_song_icon = 1;
       // both flags below get reset to 0 by song of time
-      saveData.removes_scarecrow_from_shop_0x08 = 0x08;
+      saveData.week_event_reg_79.WEEKEVENTREG_79_08 = 1;
       saveData.activate_scarecrow_song_0x01 = 0x01;
     }
   }
 
   void SaveFile_FillOverWorldMapData() {
     game::SaveData& saveData = game::GetCommonData().save;
-    saveData.overworld_map_get_flags_0x3F_for_all = 0x3F;
+    saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_CLOCK_TOWN = 1;
+    saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_WOODFALL = 1;
+    saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_SNOWHEAD = 1;
+    saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_ROMANI_RANCH = 1;
+    saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_GREAT_BAY = 1;
+    saveData.week_event_reg_35.WEEKEVENTREG_TINGLE_MAP_BOUGHT_STONE_TOWER = 1;
+
     // setting individual maps is possible if necessary, the game just ||'s the map data in.
     // Currently sets data for all maps
     saveData.overworld_map_data[0] = 0x01;
@@ -781,7 +785,7 @@ namespace rnd {
 
     // TODO: Starting stray fairies - need to update flags for which ones are acquired or not.
     if (gSettingsContext.startingSpinSettting == (u8)StartingSpinSetting::STARTINGSPIN_GREAT) {
-      saveData.has_great_spin_0x02 = 2;
+      saveData.week_event_reg_23.WEEKEVENTREG_RECEIVED_GREAT_SPIN_ATTACK = 1;
     }
 
     // Starting Notebook


### PR DESCRIPTION
Instead of randomly decomping what's needed, we can now just rename them in the new file to what they do.

140 is the total amount as that is defined in the cycle reset as well.