### PR TITLE
UTF-8 improvements and small fix

### DIFF
--- a/code/source/rnd/custom_messages.cpp
+++ b/code/source/rnd/custom_messages.cpp
@@ -456,17 +456,35 @@ public:
           sizeAtLastSpace = *size;
         // Uses UTF8 encoding so convert multi-byte representations to a single number
         if (resolvedChar > 0x7F) {
-          // Abort if char requires 3 or more bytes to represent in UTF8
-          if (resolvedChar > 0xDF) {
+          // Abort if char is not a valid first UTF8 byte
+          if (resolvedChar < 0xC0 || resolvedChar > 0xFD ) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-            rnd::util::Print("Error formatting message, unsupported character: %s\n", msg.text);
+            rnd::util::Print("Error formatting message, malformed character: %s\n", msg.text);
 #endif
 
             return;
           }
-          // Extract data from 2 byte UTF8 char. Also add the first half to the message
-          resolvedChar = ((msg.text[idx] & 0x1F) << 6) | (msg.text[idx + 1] & 0x3F);
-          addChr(msg.text[idx++]);
+          // Store whether character code will fit in resolvedChar's 16 bits
+          bool resolvedCharIsTooSmall = (resolvedChar > 0xEF);
+          // Remove first 3 bits in case char is two bytes long
+          resolvedChar &= 0x1F;
+          // Iterate through UTF8 prefix's left bits
+          for (char utfPrefix = (msg.text[idx] << 1); utfPrefix > 0x7F; utfPrefix <<= 1) {
+            // Abort if expected continuation byte is missing
+            if ((msg.text[idx + 1] >> 6) != 2) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+              rnd::util::Print("Error formatting message, malformed character: %s\n", msg.text);
+#endif
+              return;
+            }
+            // Concat next byte's bits to resolvedChar
+            resolvedChar <<= 6;
+            resolvedChar |= (msg.text[idx + 1] & 0x3F);
+            // Add current byte to message and increment
+            addChr(msg.text[idx++]);
+          }
+          // Reset resolvedChar to * if it couldn't fit value
+          if (resolvedCharIsTooSmall) {resolvedChar = 0x2A;}
         }
 
         addChr(msg.text[idx]);

--- a/code/source/rnd/gfx.cpp
+++ b/code/source/rnd/gfx.cpp
@@ -375,7 +375,7 @@ namespace rnd {
           keysFound += Dungeon_KeyAmount(dungeonId);
         }
         u32 keysFoundColor = COLOR_WHITE;
-        if (keysFound >= Dungeon_KeyAmount(dungeonId) || IsDungeonDiscovered(dungeonId)) {
+        if (keysFound >= Dungeon_KeyAmount(dungeonId) && IsDungeonDiscovered(dungeonId)) {
           keysFoundColor = COLOR_GREEN;
         } else if (keysFound == 0) {
           keysFoundColor = COLOR_DARK_GRAY;


### PR DESCRIPTION
- Should process any valid UTF-8 character without breaking
- Matches width table entries beyond `0xFF`
- Could match any character in the game's US/EU font if width table gets updated

Also keys found counter should no longer turn green early