### PR TITLE
fix: Fix reported issues with Songsanity

### DIFF
--- a/code/include/rnd/item_override.h
+++ b/code/include/rnd/item_override.h
@@ -98,21 +98,15 @@ namespace rnd {
                 // Ocarina in Inventory
     /* 0x4A */  // GI_ERROR_NOTHING_4A, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                 // Ocarina in Inventory
-    /* 0x4B */  // GI_ERROR_NOTHING_4B, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0x4C */ GI_OCARINA_OF_TIME = 0x4C,
-    /* 0x4D */  // GI_ERROR_NOTHING_4D, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0x4E */  // GI_ERROR_NOTHING_4E, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory - New Wave Bossa Nova
-    /* 0x4F */  // GI_ERROR_NOTHING_4F, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0x50 */ GI_BOMBERS_NOTEBOOK = 0x50,
-    /* 0x51 */  // GI_ERROR_YELLOW_RUPPEE, // ***ERROR TEXT Get Item Nothing in hand at first - then
-                // subsequently yellow rupee. No rupee increment.
-    /* 0x52 */ GI_GOLD_SKULLTULA_SPIRIT = 0x52,  // Pickup model is whacky since we usually don't have one.
-    /* 0x53 */  // GI_ERROR_NOTHING_53, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory Song of Time
+    /* 0x4B */ GI_SONATA_OF_AWAKENING = 0x4B,
+    /* 0x4C */ GI_OCARINA_OF_TIME,
+    /* 0x4D */ GI_GORON_LULLABY,
+    /* 0x4E */ GI_NEW_WAVE_BOSSA_NOVA,
+    /* 0x4F */ GI_ELEGY_OF_EMPTINESS,
+    /* 0x50 */ GI_BOMBERS_NOTEBOOK,
+    /* 0x51 */ GI_OATH_TO_ORDER,
+    /* 0x52 */ GI_GOLD_SKULLTULA_SPIRIT,  // Pickup model is whacky since we usually don't have one.
+    /* 0x53 */ GI_SONG_OF_TIME,
     /* 0x54 */  // GI_ERROR_NOTHING_54, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                 // Ocarina in Inventory
     /* 0x55 */ GI_ODOLWAS_REMAINS = 0x55,  // Also softlocks!
@@ -138,19 +132,15 @@ namespace rnd {
     /* 0x69 */ GI_BOTTLE_ZORA_EGG,
     /* 0x6A */ GI_BOTTLE_GOLD_DUST,
     /* 0x6B */ GI_BOTTLE_MAGIC_MUSHROOM,
-    /* 0x6C */  // GI_ERROR_NOTHING_6C, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0x6D */  // GI_BOTTLE_EMPTY_ERROR_TEXT,
+    /* 0x6C */ GI_EPONAS_SONG,
+    /* 0x6D */                             // GI_BOTTLE_EMPTY_ERROR_TEXT,
     /* 0x6E */ GI_BOTTLE_SEAHORSE = 0x6E,  // Gold Dust Actor lol
     /* 0x6F */ GI_BOTTLE_CHATEAU_ROMANI,
     /* 0x70 */ GI_BOTTLE_MYSTERY_MILK,  // Activates Timer
     /* 0x71 */ GI_BOTTLE_MOLDY_MILK,    // Mystery milk text followed by tatl.
-    /* 0x72 */  // GI_ERROR_NOTHING_72, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory. Song of Soaring.
-    /* 0x73 */  // GI_ERROR_NOTHING_73, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
-    /* 0x74 */  // GI_ERROR_NOTHING_74, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
-                // Ocarina in Inventory
+    /* 0x72 */ GI_SONG_OF_SOARING,
+    /* 0x73 */ GI_SONG_OF_STORMS,
+    /* 0x74 */ GI_GORON_LULLABY_INTRO,
     /* 0x75 */  // GI_ERROR_NOTHING_75, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with
                 // Ocarina in Inventory
     /* 0x76 */  // GI_ERROR_NOTHING_76, // ***ERROR TEXT Get Item Nothing in hand - Green Rupee with

--- a/code/source/asm/hms_patches.s
+++ b/code/source/asm/hms_patches.s
@@ -1,5 +1,10 @@
 .arm
 
+.section .patch_OverrideBombersNotebook
+.global patch_OverrideBombersNotebook
+patch_OverrideBombersNotebook:
+    b hook_OverrideHMSBombers
+
 .section .patch_HMSGiveItem
 .global patch_HMSGiveItem
 patch_HMSGiveItem:

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -59,11 +59,6 @@ SleepQueryCallback_patch:
 Gfx_Update_patch:
     b hook_Gfx_Update
 
-.section .patch_OverrideBombersNotebook
-.global patch_OverrideBombersNotebook
-patch_OverrideBombersNotebook:
-    b hook_OverrideHMSBombers
-
 .section .patch_GiveTempSwordForHandD
 .global patch_GiveTempSwordForHandD
 patch_GiveTempSwordForHandD:

--- a/code/source/asm/songsanity_hooks.s
+++ b/code/source/asm/songsanity_hooks.s
@@ -44,7 +44,7 @@ hook_LullabyCheckEnJg:
 .global hook_EnOsnCheckSoHExtData
 hook_EnOsnCheckSoHExtData:
     push {r0-r12, lr}
-    mov r0,#0x69
+    mov r0,#0x68
     bl ItemOverride_ReceivedSongOverride
     cmp r0,#0x0
     pop {r0-r12,lr}

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -107,12 +107,11 @@ namespace rnd {
 // const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     if (pressedButtons == (u32)game::pad::Button::ZR) {
-      auto& inventory = game::GetCommonData().save.inventory;
-      inventory.items[0] = game::ItemId::None;
-      inventory.collect_register.song_of_time = 0;
+      gExtSaveData.givenSongChecks.songOfSoaringGiven = 0;
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
       auto& inventory = game::GetCommonData().save.inventory;
-      inventory.items[0] = game::ItemId::Ocarina;
+      inventory.woodfall_dungeon_items.boss_key = 1;
+      // inventory.items[0] = game::ItemId::Ocarina;
     } else if (pressedButtons == (u32)game::pad::Button::Right) {
       xPos += 10.00f;
     } else if (pressedButtons == (u32)game::pad::Button::Left) {

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -111,6 +111,8 @@ namespace rnd {
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
       auto& inventory = game::GetCommonData().save.inventory;
       inventory.woodfall_dungeon_items.boss_key = 1;
+      inventory.collect_register.song_of_healing = 1;
+      game::GiveItem(game::ItemId::DekuMask);
       // inventory.items[0] = game::ItemId::Ocarina;
     } else if (pressedButtons == (u32)game::pad::Button::Right) {
       xPos += 10.00f;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -675,6 +675,29 @@ namespace rnd {
     }
   }
 
+  bool isGIDSongOrSoHItem(GetItemID incomingGetItemId) {
+    switch (incomingGetItemId) {
+    case GetItemID::GI_SONATA_OF_AWAKENING:
+    case GetItemID::GI_GORON_LULLABY:
+    case GetItemID::GI_NEW_WAVE_BOSSA_NOVA:
+    case GetItemID::GI_OATH_TO_ORDER:
+    case GetItemID::GI_SONG_OF_TIME:
+    case GetItemID::GI_EPONAS_SONG:
+    case GetItemID::GI_MASK_COUPLES:
+    case GetItemID::GI_MASK_GIBDO:
+    case GetItemID::GI_SONG_OF_SOARING:
+    case GetItemID::GI_SONG_OF_STORMS:
+    case GetItemID::GI_GORON_LULLABY_INTRO:
+    case GetItemID::GI_MASK_DEKU:
+    case GetItemID::GI_MASK_GORON:
+    case GetItemID::GI_MASK_ZORA:
+    case GetItemID::GI_ELEGY_OF_EMPTINESS:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   extern "C" {
   bool ItemOverride_CheckAromaGivenItem() {
     if (gExtSaveData.givenItemChecks.enAlGivenItem > 0)
@@ -729,11 +752,11 @@ namespace rnd {
     s32 incomingNegative = incomingGetItemId < 0;
     if (fromActor != NULL && incomingGetItemId != 0) {
       s16 getItemId = ItemOverride_CheckNpc(fromActor->id, incomingGetItemId, incomingNegative);
-      // #if defined ENABLE_DEBUG || DEBUG_PRINT
-      //       util::Print("%s: Our actor ID is %#06x\nScene is %#04x\nIncoming item id is %#04x\ngetItemId
-      //       %#04x\nParams %#04x\n", __func__, fromActor->id,
-      //                   gctx->scene, incomingGetItemId, getItemId, fromActor->params);
-      // #endif
+#if defined ENABLE_DEBUG || DEBUG_PRINT
+      util::Print(
+          "%s: Our actor ID is %#06x\nScene is %#04x\nIncoming item id is %#04x\ngetItemId %#04x\nParams %#04x\n ",
+          __func__, fromActor->id, gctx->scene, incomingGetItemId, getItemId, fromActor->params);
+#endif
       storedActorId = fromActor->id;
       storedGetItemId = incomingNegative ? (GetItemID)-incomingGetItemId : (GetItemID)incomingGetItemId;
       override = ItemOverride_Lookup(fromActor, (u16)gctx->scene, getItemId);
@@ -886,11 +909,7 @@ namespace rnd {
     // Edge case with Song of healing items. Override their show text in their own functions
     // to ensure that we have the same 'feel' as the base game.
     // This also ensures that if there is no override the default text still works.
-    if (incomingGetItemId == 0x4B || incomingGetItemId == 0x4D || incomingGetItemId == 0x4E ||
-        incomingGetItemId == 0x51 || incomingGetItemId == 0x53 || incomingGetItemId == 0x6C ||
-        (incomingGetItemId <= 0x72 && incomingGetItemId >= 0x74) ||
-        (incomingGetItemId >= 0x78 && incomingGetItemId <= 0x7A) || incomingGetItemId == 0x85 ||
-        incomingGetItemId == 0x87) {
+    if (isGIDSongOrSoHItem(static_cast<GetItemID>(incomingGetItemId))) {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
       rnd::util::Print("%s: Must be a song, storing text ID %#04x for incomingItemId %#04x.\n", __func__,
                        rActiveItemRow->textId, incomingGetItemId);
@@ -1072,7 +1091,7 @@ namespace rnd {
   void ItemOverride_SwapSoHAndSongGetItemText(game::GlobalContext* gctx, u16 textId, game::act::Actor* fromActor) {
 // Check which text ID is coming in. If it's any mask from Song of Healing, replace it with active item text.
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: txtId = %#08x\n", __func__, textId);
+    rnd::util::Print("%s: txtId = %#08x \n", __func__, textId);
 #endif
     if (givenItemOverride) {
       givenItemOverride = false;

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -1078,6 +1078,13 @@ namespace rnd {
         : (int)0xFF;
     } else if (currentItem == game::ItemId::Ocarina) {
       return (int) currentItem; // XXX: Use this to fix Termina being in Cycle 1.
+    } else if (currentItem == game::ItemId::DekuMask) {
+      auto* gctx = GetContext().gctx;
+      if(gctx->scene == game::SceneId::ClockTowerInterior) {
+        return givenItems.enOsnGivenMask ? (int) currentItem
+          : (int)0xFF;
+      }
+      
     }
     // Use the standard pointer to array as this seems to mess with
     // some issues in checking items such as trade items, and Giant's Mask.

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -1270,11 +1270,10 @@ namespace rnd {
   game::OcarinaSong ItemOverride_ChangeEnGkSong() {
     game::GlobalContext* gctx = GetContext().gctx;
     game::OcarinaSong lastPlayedSong = gctx->msg_context.lastPlayedSong;
-    if ((lastPlayedSong == game::OcarinaSong::GoronLullaby) && gExtSaveData.givenSongChecks.goronLullabyGiven == 0) {
+    if ((lastPlayedSong == game::OcarinaSong::GoronLullaby) && gExtSaveData.givenSongChecks.goronLullabyGiven < 2) {
       gctx->msg_context.lastPlayedSong = game::OcarinaSong::GoronLullablyIntro;
       return game::OcarinaSong::GoronLullablyIntro;
     }
-
     return lastPlayedSong;
   }
   }

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -583,7 +583,7 @@ namespace rnd {
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSong, (s16)10, (s16)-1,
                         1.00f),  // Song Of Storms
 
-      [0x74] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronLullaby, 0x1BAC,
+      [0x74] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::GoronLullabyIntro, 0x1BAC,
                         0x00B5, 0x00, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, DrawGraphicItemID::DI_NONE,
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSong, (s16)11, (s16)-1,
                         1.00f),  // Goron Lullaby Intro


### PR DESCRIPTION
The following has been patched:
- Goron Lullaby now respects elder goron being talked to. Prior to this, if you talked to elder goron and got the lullaby intro check, you would be locked out of the elder son's lullaby check.
- Happy Mask Salesman (EnOsn) would constantly repeat the song of healing check if talked to. 
- Happy Mask Salesman (EnOsn) would repeat the song of healing cutscene on moon crash
- Items received by Song checks would have both get item text and song text show. 

