### PR TITLE
feat: Include Moon and Majora Mask Requirements

### DIFF
--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -209,6 +209,15 @@ namespace game {
   static_assert(sizeof(InventoryData) == 0xD4);
   static_assert(offsetof(InventoryData, inventory_count_register) == 0x78);
 
+  struct CycleSceneFlags {
+    u32 switch0;
+    u32 switch1;
+    u32 chest;
+    u32 clearedRoom;
+    u32 collectible;
+  };
+  static_assert(sizeof(CycleSceneFlags) == 0x14);
+
   struct SaveData {
     // Todo: rename gaps to match savefile address location
     MaskId mask;
@@ -787,10 +796,8 @@ namespace game {
     u16 time_copy_3;
     char field_13762;
     char next_transition_type;
-    u8 gap_13764[2204];
-    u32 field_14000;
-    u8 gap_14004[192];
-    int field_140C4;
+    int field_13764;
+    CycleSceneFlags cycleSceneFlags[120];
     int field_140C8;
     int field_140CC;
     int field_140D0;
@@ -811,6 +818,7 @@ namespace game {
   static_assert(offsetof(CommonData, field_3676) == 0x3676);
   static_assert(offsetof(CommonData, gap_1361A) == 0x1361A);
   static_assert(offsetof(CommonData, pictograph_data) == 0x36CC);
+  static_assert(offsetof(CommonData, cycleSceneFlags) == 0x13768);
   static_assert(offsetof(CommonData, field_140F2) == 0x140F2);
 
   CommonData& GetCommonData();

--- a/code/include/game/common_data.h
+++ b/code/include/game/common_data.h
@@ -654,6 +654,7 @@ namespace game {
     int field_10;
     int field_14;
   };
+  static_assert(sizeof(CommonDataSub12) == 0x18);
 
   struct RespawnData {
     z3dVec3f pos;
@@ -738,7 +739,7 @@ namespace game {
     u16 field_3698;
     u16 field_369A;
     u16 field_369C;
-    u16 field_369E;
+    u16 next_cutscene_index;
     u16 time_copy_2;
     // Used for scheduling NPCs?
     u16 time_copy;
@@ -785,7 +786,7 @@ namespace game {
     char field_1375F;
     u16 time_copy_3;
     char field_13762;
-    char field_13763;
+    char next_transition_type;
     u8 gap_13764[2204];
     u32 field_14000;
     u8 gap_14004[192];
@@ -805,6 +806,12 @@ namespace game {
     int field_140F4;
   };
   static_assert(sizeof(CommonData) == 0x140F8);
+  static_assert(offsetof(CommonData, next_cutscene_index) == 0x369E);
+  static_assert(offsetof(CommonData, gap_3668) == 0x3668);
+  static_assert(offsetof(CommonData, field_3676) == 0x3676);
+  static_assert(offsetof(CommonData, gap_1361A) == 0x1361A);
+  static_assert(offsetof(CommonData, pictograph_data) == 0x36CC);
+  static_assert(offsetof(CommonData, field_140F2) == 0x140F2);
 
   CommonData& GetCommonData();
 

--- a/code/include/game/context.h
+++ b/code/include/game/context.h
@@ -516,7 +516,11 @@ namespace game {
     u8 field_C530;
     u8 field_C531;
     u8 field_C532;
-    u8 gap_C533[5];
+    // u8 gap_C533[5];
+    u8 gap_C533;
+    u8 transitionType;
+    u8 field_C535;
+    u16 field_C536;
     int field_C538;
     u8 gap_C53C[798];
     u8 field_C85A;
@@ -623,6 +627,8 @@ namespace game {
   static_assert(offsetof(GlobalContext, msg_context.ocarinaMode) == 0x8366);
   static_assert(offsetof(GlobalContext, gap_404) == 0x0404);
   static_assert(offsetof(GlobalContext, object_context) == 0x9438);
+  static_assert(offsetof(GlobalContext, transitionType) == 0xC534);
+  static_assert(offsetof(GlobalContext, field_C538) == 0xC538);
   static_assert(sizeof(GlobalContext) == 0x11030);
 
   struct PersistentSceneCycleFlags {

--- a/code/include/game/context.h
+++ b/code/include/game/context.h
@@ -51,22 +51,6 @@ namespace game {
   };
   static_assert(sizeof(ActorList) == 0xc);
 
-  struct ActorLists {
-    ActorList& GetList(act::Type type) { return lists[u8(type)]; }
-    const ActorList& GetList(act::Type type) const { return lists[u8(type)]; }
-    u8 freeze_flash_timer;
-    u8 pad1;
-    u8 field_2;
-    u8 lens_active;
-    u8 lens_mask_size;
-    u8 flag;
-    u8 gap_6[6];
-    u8 num_actors;
-    std::array<ActorList, 12> lists;
-  };
-  static_assert(sizeof(ActorLists) == 0xa0);
-  static_assert(offsetof(ActorLists, gap_6) == 0x06);
-
   struct ActorContextSceneFlags {
     u32 switches[4];  // First 0x40 are permanent, second 0x40 are temporary
     u32 chest;
@@ -98,6 +82,35 @@ namespace game {
     u16 field_10;
   };
   static_assert(sizeof(TitleCardContext) == 0x14);
+
+  struct ActorLists {
+    ActorList& GetList(act::Type type) { return lists[u8(type)]; }
+    const ActorList& GetList(act::Type type) const { return lists[u8(type)]; }
+    u8 freeze_flash_timer;
+    u8 pad1;
+    u8 field_2;
+    u8 lens_active;
+    u8 lens_mask_size;
+    u8 flag;
+    u8 gap_6[6];
+    u8 num_actors;
+    std::array<ActorList, 12> lists;
+    u8 gap_2150[128];
+    z3dVec3f field_21D0;
+    u8 gap_21DC[280];
+    ActorContextSceneFlags actor_ctx_scene_flags;
+    TitleCardContext title_card_ctx;
+    PlayerImpact player_impact;
+    u8 gap_2348[72];
+    void* absolute_space;
+    std::array<act::ObjElegyStatue*, 5> elegy_statues;
+    char field_23A8;
+    u8 gap_23A9[3];
+    pad::State pad_state_copy;
+    u8 gap_2418[12];
+  };
+  static_assert(sizeof(ActorLists) == 0x374);
+  static_assert(offsetof(ActorLists, gap_6) == 0x06);
 
   enum class OcarinaMode : u16 {
     OCARINA_MODE_NONE = 0,
@@ -436,7 +449,7 @@ namespace game {
     u32 field_2000;
     u8 gap_2004[172];
     ActorLists actors;
-    u8 gap_2150[128];
+    /*u8 gap_2150[128];
     z3dVec3f field_21D0;
     u8 gap_21DC[280];
     ActorContextSceneFlags actor_ctx_scene_flags;
@@ -448,7 +461,7 @@ namespace game {
     char field_23A8;
     u8 gap_23A9[3];
     pad::State pad_state_copy;
-    u8 gap_2418[12];
+    u8 gap_2418[12];*/
     int field_2424;
     u32 field_2428;
     u8 gap_242C[604];
@@ -627,8 +640,8 @@ namespace game {
   };
   static_assert(offsetof(GlobalContext, main_camera) == 0x408);
   static_assert(offsetof(GlobalContext, pause_flags) == 0xAAC);
-  static_assert(offsetof(GlobalContext, elegy_statues) == 0x2394);
-  static_assert(offsetof(GlobalContext, gap_2348) == 0x2348);
+  static_assert(offsetof(GlobalContext, actors.elegy_statues) == 0x2394);
+  static_assert(offsetof(GlobalContext, actors.gap_2348) == 0x2348);
   static_assert(offsetof(GlobalContext, field_C000) == 0xc000);
   static_assert(offsetof(GlobalContext, field_C4C8) == 0xC4C8);
   static_assert(offsetof(GlobalContext, gap_AC6C) == 0xAC6C);

--- a/code/include/game/context.h
+++ b/code/include/game/context.h
@@ -54,37 +54,50 @@ namespace game {
   struct ActorLists {
     ActorList& GetList(act::Type type) { return lists[u8(type)]; }
     const ActorList& GetList(act::Type type) const { return lists[u8(type)]; }
-    u8 gap_0[4];
-    u8 field_4;
-    u8 field_5;
+    u8 freeze_flash_timer;
+    u8 pad1;
+    u8 field_2;
+    u8 lens_active;
+    u8 lens_mask_size;
+    u8 flag;
     u8 gap_6[6];
     u8 num_actors;
     std::array<ActorList, 12> lists;
   };
   static_assert(sizeof(ActorLists) == 0xa0);
+  static_assert(offsetof(ActorLists, gap_6) == 0x06);
 
-  enum class OcarinaState : u16 {
-    NotOpened = 0,
-    Playing = 1,
-    PlayingAndReplayDone = 3,
-    StoppedPlaying = 4,
-    PlayedSongOfTime = 0x12,
-    PlayedInvertedSongOfTime = 0x13,
-    GoingBackInTime = 0x16,
-    RestoringTimeToNormalSpeed = 0x18,
-    SlowingTime = 0x19,
-    JumpingForwardInTime = 0x1a,
-    WarpingToGreatBayCoast = 0x1c,
-    WarpingToZoraCape = 0x1d,
-    WarpingToSnowhead = 0x1e,
-    WarpingToMountainVillage = 0x1f,
-    WarpingToClockTown = 0x20,
-    WarpingToMilkRoad = 0x21,
-    WarpingToWoodfall = 0x22,
-    WarpingToSouthernSwamp = 0x23,
-    WarpingToIkanaCanyon = 0x24,
-    WarpingToStoneTower = 0x25,
+  struct ActorContextSceneFlags {
+    u32 switches[4];  // First 0x40 are permanent, second 0x40 are temporary
+    u32 chest;
+    u32 clearedRoom;
+    u32 clearedRoomTemp;
+    u32 collectible[4];  // bitfield of 128 bits
   };
+  static_assert(sizeof(ActorContextSceneFlags) == 0x2C);
+
+  struct PlayerImpact {
+    u8 timer;
+    u8 type;
+    float dist;
+    z3dVec3f pos;
+  };
+  static_assert(sizeof(PlayerImpact) == 0x14);
+
+  struct TitleCardContext {
+    void* texturePtr;
+    s16 x;
+    s16 y;
+    u8 width;
+    u8 height;
+    u8 durationTimer;
+    u8 delayTimer;
+    u8 alpha;
+    u8 intensity;
+    u16 field_e;
+    u16 field_10;
+  };
+  static_assert(sizeof(TitleCardContext) == 0x14);
 
   enum class OcarinaMode : u16 {
     OCARINA_MODE_NONE = 0,
@@ -425,23 +438,18 @@ namespace game {
     ActorLists actors;
     u8 gap_2150[128];
     z3dVec3f field_21D0;
-    u8 gap_21DC[284];
-    int field_22f3;
-    int field_22FC;
-    u8 gap_2300[8];
-    int room_number_mask;
-    u8 gap_230C[4];
-    u8 field_2310;
-    u8 gap_2311[3];
-    int field_2314;
-    int field_2318;
-    int field_231C;
-    u8 gap_2320[116];
+    u8 gap_21DC[280];
+    ActorContextSceneFlags actor_ctx_scene_flags;
+    TitleCardContext title_card_ctx;
+    PlayerImpact player_impact;
+    u8 gap_2348[72];
+    void* absolute_space;
     std::array<act::ObjElegyStatue*, 5> elegy_statues;
     char field_23A8;
     u8 gap_23A9[3];
     pad::State pad_state_copy;
-    u8 gap_2418[16];
+    u8 gap_2418[12];
+    int field_2424;
     u32 field_2428;
     u8 gap_242C[604];
     u32 field_2688;
@@ -620,6 +628,7 @@ namespace game {
   static_assert(offsetof(GlobalContext, main_camera) == 0x408);
   static_assert(offsetof(GlobalContext, pause_flags) == 0xAAC);
   static_assert(offsetof(GlobalContext, elegy_statues) == 0x2394);
+  static_assert(offsetof(GlobalContext, gap_2348) == 0x2348);
   static_assert(offsetof(GlobalContext, field_C000) == 0xc000);
   static_assert(offsetof(GlobalContext, field_C4C8) == 0xC4C8);
   static_assert(offsetof(GlobalContext, gap_AC6C) == 0xAC6C);

--- a/code/include/game/weekeventreg.h
+++ b/code/include/game/weekeventreg.h
@@ -370,7 +370,7 @@ namespace game {
     u8 raw;
 
     BitField<0, 1, u8> WEEKEVENTREG_RECEIVED_BEAVER_BROS_HEART_PIECE;
-    BitField<1, 1, u8> WEEKEVENTREG_25_02;
+    BitField<1, 1, u8> WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED;
     BitField<2, 1, u8> WEEKEVENTREG_25_04;
     BitField<3, 1, u8> WEEKEVENTREG_BREMAN_MASK_USED;
     BitField<4, 1, u8> WEEKEVENTREG_25_10;

--- a/code/include/game/weekeventreg.h
+++ b/code/include/game/weekeventreg.h
@@ -1247,7 +1247,7 @@ namespace game {
     u8 raw;
     BitField<0, 1, u8> WEEKEVENTREG_93_01;
     BitField<1, 1, u8> WEEKEVENTREG_93_02;
-    BitField<2, 1, u8> WEEKEVENTREG_93_04;
+    BitField<2, 1, u8> WEEKEVENTREG_CALLED_GIANTS_ON_ROOFTOP_ONCE;
     BitField<3, 1, u8> WEEKEVENTREG_93_08;
     BitField<4, 1, u8> WEEKEVENTREG_93_10;
     BitField<5, 1, u8> WEEKEVENTREG_93_20;

--- a/code/include/rnd/actors/en_giant.h
+++ b/code/include/rnd/actors/en_giant.h
@@ -1,0 +1,10 @@
+#ifndef _RND_ACTOR_EN_GIANT_H_
+#define _RND_ACTOR_EN_GIANT_H_
+#include "rnd/settings.h"
+namespace rnd {
+  extern "C" {
+  void En_Giant_ShouldDrawGiant(game::act::Actor*);
+  bool En_Giant_KillAfterCutscene(game::act::Actor*);
+  }
+}  // namespace rnd
+#endif

--- a/code/include/rnd/actors/en_js.h
+++ b/code/include/rnd/actors/en_js.h
@@ -5,7 +5,10 @@
 #include "rnd/settings.h"
 namespace rnd
 {
-  extern "C" u16 En_Js_CheckVictoryRequirements();
+  extern "C"  {
+  u16 En_Js_CurrentMasksInInventory();
+  u16 En_Js_CheckVictoryRequirements();
+  }
 } // namespace rnd
 
 

--- a/code/include/rnd/actors/en_js.h
+++ b/code/include/rnd/actors/en_js.h
@@ -1,0 +1,12 @@
+#ifndef _RND_ACTOR_EN_JS_H_
+#define _RND_ACTOR_EN_JS_H_
+#include "game/common_data.h"
+#include "rnd/savefile.h"
+#include "rnd/settings.h"
+namespace rnd
+{
+  extern "C" u16 En_Js_CheckVictoryRequirements();
+} // namespace rnd
+
+
+#endif

--- a/code/include/rnd/actors/en_js.h
+++ b/code/include/rnd/actors/en_js.h
@@ -3,13 +3,11 @@
 #include "game/common_data.h"
 #include "rnd/savefile.h"
 #include "rnd/settings.h"
-namespace rnd
-{
-  extern "C"  {
+namespace rnd {
+  extern "C" {
   u16 En_Js_CurrentMasksInInventory();
   u16 En_Js_CheckVictoryRequirements();
   }
-} // namespace rnd
-
+}  // namespace rnd
 
 #endif

--- a/code/include/rnd/custom_entrances.h
+++ b/code/include/rnd/custom_entrances.h
@@ -17,6 +17,7 @@ namespace rnd {
   extern "C" {
   bool SceneEntranceOverride();
   void ForceTempleFlags();
+  bool CheckMoonRequirements();
   }
 }  // namespace rnd
 

--- a/code/include/rnd/custom_entrances.h
+++ b/code/include/rnd/custom_entrances.h
@@ -17,7 +17,7 @@ namespace rnd {
   extern "C" {
   bool SceneEntranceOverride();
   void ForceTempleFlags();
-  bool CheckMoonRequirements();
+  bool EnFall_CheckMoonRequirements();
   }
 }  // namespace rnd
 

--- a/code/include/rnd/objects.h
+++ b/code/include/rnd/objects.h
@@ -12,9 +12,6 @@ namespace rnd {
   typedef game::ActorResource::ObjectContext ExtendedObjectContext;
   extern "C" ExtendedObjectContext rExtendedObjectCtx;
   extern "C" s32 rStoredObjId;
-  extern "C" s32 yPos;
-  extern "C" s32 xPos;
-  extern "C" s32 zPos;
 
   s32 Object_SpawnPersistent(void* objectCtx, s16 objectId);
   s32 Object_GetSlot(void* objectCtx, s16 objectId);

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -39,7 +39,6 @@ namespace rnd {
   void SaveFile_RemoveTradeItemFromSlot(u16, u8);
   u8 SaveFile_GetItemCurrentlyInSlot(u8);
   void SaveFile_SetNextTradeSlotItem(u8);
-  u16 CurrentMasksInInventory();
   void SaveFile_UpdateBossExtData();
   }
 

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -449,6 +449,7 @@ namespace rnd {
   extern const char hashIconNames[62][25];
 
   extern "C" s32 Settings_ApplyDamageMultiplier(game::GlobalContext*, s32);
+  u16 Settings_CountRemainsCollected();
   u32 Hash(u32);
   u8 Bias(u32);
 }  // namespace rnd

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -438,6 +438,10 @@ namespace rnd {
     // Extra MM Settings
     u8 blastMaskCooldown;
 
+    // Moon Settings
+    u8 masksNeededToEnterMoon;
+    u8 masksNeededForVictory;
+
     u8 useFierceDeityAnywhere = 0;
   } SettingsContext;
 

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -426,6 +426,7 @@ namespace rnd {
     u8 skipHMSCutscenes;
     u8 skipMikauCutscene;
     u8 skipDarmaniCutscene;
+    u8 skipGiantsCutscene;
 
     // Custom Buttons
     u32 customMapButton = 0;

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -752,6 +752,10 @@ SECTIONS{
     *(.patch_EnGkCheckLullabyRewardGiven)
   }
 
+  .patch_AdjustMoonEntryRequirements 0x576D48 : {
+    *(.patch_AdjustMoonEntryRequirements)
+  }
+
   .patch_EnMkNWBNOverride 0x58722C : {
     *(.patch_EnMkNWBNOverride)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -756,6 +756,10 @@ SECTIONS{
     *(.patch_AdjustMoonEntryRequirements)
   }
 
+  .patch_EnJsVictoryCheck 0x57C178 : {
+    *(.patch_EnJsVictoryCheck)
+  }
+
   .patch_EnMkNWBNOverride 0x58722C : {
     *(.patch_EnMkNWBNOverride)
   }

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -125,8 +125,8 @@ SECTIONS{
     *(.patch_DoNotResetTempleFlags)
   }
 
-  .patch_DoNotResetPermFlags 0x1C9348 : {
-    *(.patch_DoNotResetPermFlags)
+  .patch_DoNotResetCurrentSceneFlags 0x1C9348 : {
+    *(.patch_DoNotResetCurrentSceneFlags)
   }
 
   .patch_DoNotRemoveTradeItems 0x1C9AA8 : {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -543,6 +543,10 @@ SECTIONS{
       *(.patch_RemoveWoodfallClearConditionFromBoatHouse)
   }
 
+  .patch_DrawGiantAfterMoonCutscene 0x39A53C : {
+    *(.patch_DrawGiantAfterMoonCutscene)
+  }
+
   .patch_DmChar03ModelDraw 0x3B9254 : {
     *(.patch_DmChar03ModelDraw)
   }
@@ -762,6 +766,10 @@ SECTIONS{
 
   .patch_EnMkNWBNOverride 0x58722C : {
     *(.patch_EnMkNWBNOverride)
+  }
+
+  .patch_EnGiantDrawGiantIfMoonRequirementsMet 0x58AB24 : {
+    *(.patch_EnGiantDrawGiantIfMoonRequirementsMet)
   }
 
   .patch_UpdateOcarinaVisibility 0x59AA2C : {

--- a/code/source/asm/en_giant_hooks.s
+++ b/code/source/asm/en_giant_hooks.s
@@ -1,0 +1,21 @@
+.arm
+.text
+
+.global hook_DrawGiantAfterMoonCutscene
+hook_DrawGiantAfterMoonCutscene:
+    beq 0x39A66C @Default instruction if weekeventreg is false.
+    push {r0-r12,lr}
+    cpy r0,r4
+    bl En_Giant_KillAfterCutscene
+    cmp r0,#0x0
+    pop {r0-r12,lr}
+    beq 0x39A66C
+    bne 0x39A544
+
+.global hook_EnGiantDrawGiantIfMoonRequirementsMet
+hook_EnGiantDrawGiantIfMoonRequirementsMet:
+    push {r0-r12,lr}
+    cpy r0,r4
+    bl En_Giant_ShouldDrawGiant
+    pop {r0-r12,lr}
+    b 0x58AB30

--- a/code/source/asm/en_giant_patches.s
+++ b/code/source/asm/en_giant_patches.s
@@ -1,0 +1,11 @@
+.arm
+
+.section .patch_DrawGiantAfterMoonCutscene
+.global patch_DrawGiantAfterMoonCutscene
+patch_DrawGiantAfterMoonCutscene:
+    b hook_DrawGiantAfterMoonCutscene
+
+.section .patch_EnGiantDrawGiantIfMoonRequirementsMet
+.global patch_EnGiantDrawGiantIfMoonRequirementsMet
+patch_EnGiantDrawGiantIfMoonRequirementsMet:
+    b hook_EnGiantDrawGiantIfMoonRequirementsMet

--- a/code/source/asm/entrance_hooks.s
+++ b/code/source/asm/entrance_hooks.s
@@ -25,7 +25,7 @@ hook_DoNotResetTempleFlags:
 hook_AdjustMoonEntryRequirements:
     ldr r2,[r3,#0x0]
     push {r0-r12, lr}
-    bl CheckMoonRequirements
+    bl EnFall_CheckMoonRequirements
     cmp r0,#0x1
     pop {r0-r12, lr}
     bne 0x576DFC @Did not meet requirements for moon.

--- a/code/source/asm/entrance_hooks.s
+++ b/code/source/asm/entrance_hooks.s
@@ -1,0 +1,32 @@
+.arm
+.text
+
+.global hook_OverrideCutsceneNextEntrance
+hook_OverrideCutsceneNextEntrance:
+    push {r0-r12, lr}
+    bl SceneEntranceOverride
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    bne doNotOverrideCutscene
+    bx lr
+doNotOverrideCutscene:
+    bl 0x22A7F8
+    b 0x1B1838
+
+.global hook_DoNotResetTempleFlags
+hook_DoNotResetTempleFlags:
+    push {r0-r12, lr}
+    bl ForceTempleFlags
+    pop {r0-r12, lr}
+    mov r0,#0x0
+    bx lr
+
+.global hook_AdjustMoonEntryRequirements
+hook_AdjustMoonEntryRequirements:
+    ldr r2,[r3,#0x0]
+    push {r0-r12, lr}
+    bl CheckMoonRequirements
+    cmp r0,#0x1
+    pop {r0-r12, lr}
+    bne 0x576DFC @Did not meet requirements for moon.
+    beq 0x576D6C @Met moon requirements.

--- a/code/source/asm/entrance_patches.s
+++ b/code/source/asm/entrance_patches.s
@@ -1,0 +1,20 @@
+.arm
+
+.section .patch_OverrideCutsceneNextEntrance
+.global patch_OverrideCutsceneNextEntrance
+patch_OverrideCutsceneNextEntrance:
+    bl hook_OverrideCutsceneNextEntrance
+
+@ Skip past all the fairy and 
+@ door resetting if we are the temples
+@ as we don't want to softlock users
+@ if they have already used their keys.
+.section .patch_DoNotResetTempleFlags
+.global patch_DoNotResetTempleFlags
+patch_DoNotResetTempleFlags:
+    bl hook_DoNotResetTempleFlags
+
+.section .patch_AdjustMoonEntryRequirements
+.global patch_AdjustMoonEntryRequirements
+patch_AdjustMoonEntryRequirements:
+    b hook_AdjustMoonEntryRequirements

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -59,26 +59,6 @@ hook_RemoveTempSwordForHandD:
     cpy r12, r1
     bx lr
 
-.global hook_OverrideCutsceneNextEntrance
-hook_OverrideCutsceneNextEntrance:
-    push {r0-r12, lr}
-    bl SceneEntranceOverride
-    cmp r0,#0x1
-    pop {r0-r12, lr}
-    bne doNotOverrideCutscene
-    bx lr
-doNotOverrideCutscene:
-    bl 0x22A7F8
-    b 0x1B1838
-
-.global hook_DoNotResetTempleFlags
-hook_DoNotResetTempleFlags:
-    push {r0-r12, lr}
-    bl ForceTempleFlags
-    pop {r0-r12, lr}
-    mov r0,#0x0
-    bx lr
-
 .global hook_SpawnFastElegyStatues
 hook_SpawnFastElegyStatues:
     push {r0-r12, lr}

--- a/code/source/asm/hooks.s
+++ b/code/source/asm/hooks.s
@@ -167,15 +167,6 @@ hook_EnteringLocation:
     cpy r9,r0
     bx lr
 
-.global hook_CheckMasksOnMoon
-hook_CheckMasksOnMoon:
-    push {r5-r12,lr}
-    bl CurrentMasksInInventory
-    cpy r4,r0
-    pop {r5-r12, lr}
-    mov r0,#0x0
-    bx lr
-
 .global hook_readGamePad
 hook_readGamePad:
     push {r0-r12, lr}

--- a/code/source/asm/moon_child_hooks.s
+++ b/code/source/asm/moon_child_hooks.s
@@ -1,0 +1,19 @@
+.arm
+.text
+
+.global hook_CheckMasksOnMoon
+hook_CheckMasksOnMoon:
+    push {r5-r12,lr}
+    bl CurrentMasksInInventory
+    cpy r4,r0
+    pop {r5-r12, lr}
+    mov r0,#0x0
+    bx lr
+
+.global hook_EnJsVictoryCheck
+hook_EnJsVictoryCheck:
+    push {r0, r2-r12, lr}
+    bl En_Js_CheckVictoryRequirements
+    mov r1,r0
+    pop {r0, r2-r12, lr}
+    bx lr

--- a/code/source/asm/moon_child_hooks.s
+++ b/code/source/asm/moon_child_hooks.s
@@ -4,7 +4,7 @@
 .global hook_CheckMasksOnMoon
 hook_CheckMasksOnMoon:
     push {r5-r12,lr}
-    bl CurrentMasksInInventory
+    bl En_Js_CurrentMasksInInventory
     cpy r4,r0
     pop {r5-r12, lr}
     mov r0,#0x0

--- a/code/source/asm/moon_child_patches.s
+++ b/code/source/asm/moon_child_patches.s
@@ -1,0 +1,11 @@
+.arm
+
+.section .patch_CheckMasksOnMoon
+.global patch_CheckMasksOnMoon
+patch_CheckMasksOnMoon:
+    bl hook_CheckMasksOnMoon
+
+.section .patch_EnJsVictoryCheck
+.global patch_EnJsVictoryCheck
+patch_EnJsVictoryCheck:
+    bl hook_EnJsVictoryCheck

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -74,11 +74,6 @@ patch_RemoveTempSwordForHandD:
 patch_KeepBowOnEpona:
     nop
 
-.section .patch_OverrideCutsceneNextEntrance
-.global patch_OverrideCutsceneNextEntrance
-patch_OverrideCutsceneNextEntrance:
-    bl hook_OverrideCutsceneNextEntrance
-
 @ There's a while loop located in the event
 @ timer that checks if we have mystery milk.
 @ We do not wish to show this since we want to remove
@@ -87,16 +82,6 @@ patch_OverrideCutsceneNextEntrance:
 .global patch_RemoveMysteryMilkTimer
 patch_RemoveMysteryMilkTimer:
     nop
-
-@ Skip past all the fairy and 
-@ door resetting if we are the temples
-@ as we don't want to softlock users
-@ if they have already used their keys.
-.section .patch_DoNotResetTempleFlags
-.global patch_DoNotResetTempleFlags
-patch_DoNotResetTempleFlags:
-    bl hook_DoNotResetTempleFlags
-
 
 @ Skips past a loop that resets all
 @ values in the each dungeon for 

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -26,9 +26,9 @@ patch_ResetCycleFlagOnMoonCrash:
     bl 0x1C92A8
 
 @ nop gctx->field_22f8 from being potentially nulled. Disables stray fairy respawn and doors locking.
-.section .patch_DoNotResetPermFlags
-.global patch_DoNotResetPermFlags
-patch_DoNotResetPermFlags:
+.section .patch_DoNotResetCurrentSceneFlags
+.global patch_DoNotResetCurrentSceneFlags
+patch_DoNotResetCurrentSceneFlags:
     nop
     nop
     nop

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -83,6 +83,11 @@ patch_KeepBowOnEpona:
 patch_RemoveMysteryMilkTimer:
     nop
 
+.section .patch_tmp
+.global patch_tmp
+patch_tmp:
+    b 0x34EA0C
+
 @ Skips past a loop that resets all
 @ values in the each dungeon for 
 @ keys/fairies/boss key/etc
@@ -246,11 +251,6 @@ patch_RemoveBombers:
 .global patch_RemoveSoHMaskAppearing
 patch_RemoveSoHMaskAppearing:
     nop
-
-.section .patch_CheckMasksOnMoon
-.global patch_CheckMasksOnMoon
-patch_CheckMasksOnMoon:
-    bl hook_CheckMasksOnMoon
 
 .section .patch_RemoveJimWhenExitingHideout
 .global RemoveJimWhenExitingHideout_patch

--- a/code/source/game/items.cpp
+++ b/code/source/game/items.cpp
@@ -865,7 +865,7 @@ namespace game {
     if (item == ItemId::FierceDeityMask)
       return IsBossRoomScene(gctx);
 
-    if (gctx->actors.field_4) {
+    if (gctx->actors.lens_mask_size) {
       if (rnd::util::IsAnyOf(item, ItemId::FireArrow, ItemId::IceArrow, ItemId::LightArrow))
         return false;
     }

--- a/code/source/game/player.cpp
+++ b/code/source/game/player.cpp
@@ -84,10 +84,10 @@ namespace game::act {
     if (player->timer == 1) {
       auto spawn_elegy_statue = rnd::util::GetPointer<void(GlobalContext*, Player*)>(0x1F0758);
       spawn_elegy_statue(gctx, player);
-      auto* statue = gctx->elegy_statues[u8(player->active_form)];
+      auto* statue = gctx->actors.elegy_statues[u8(player->active_form)];
       statue->timer = 0;
     } else if (player->timer > 5) {
-      auto* statue = gctx->elegy_statues[u8(player->active_form)];
+      auto* statue = gctx->actors.elegy_statues[u8(player->active_form)];
       const bool statue_ready =
           !statue || (statue->pos.pos.x == player->pos.pos.x && statue->pos.pos.y == player->pos.pos.y &&
                       statue->pos.pos.z == player->pos.pos.z);

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -109,11 +109,8 @@ namespace rnd {
     if (pressedButtons == (u32)game::pad::Button::ZR) {
       gExtSaveData.givenSongChecks.songOfSoaringGiven = 0;
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
-      auto& inventory = game::GetCommonData().save.inventory;
-      inventory.woodfall_dungeon_items.boss_key = 1;
-      inventory.collect_register.song_of_healing = 1;
-      game::GiveItem(game::ItemId::DekuMask);
-      // inventory.items[0] = game::ItemId::Ocarina;
+      auto& save = game::GetCommonData().save;
+      save.week_event_reg_93.WEEKEVENTREG_CALLED_GIANTS_ON_ROOFTOP_ONCE = 1;
     } else if (pressedButtons == (u32)game::pad::Button::Right) {
       xPos += 10.00f;
     } else if (pressedButtons == (u32)game::pad::Button::Left) {

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -103,22 +103,46 @@ namespace rnd {
     if (!gctx || gctx->type != game::StateType::Play)
       return;
 
-    const u32 pressedButtons = gctx->pad_state.input.buttons.flags;
+    const u32 pressedButtons = gctx->pad_state.input.new_buttons.flags;
 // const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     if (pressedButtons == (u32)game::pad::Button::ZR) {
       auto& cdata = game::GetCommonData();
+      rnd::util::Print("%s: cdata.cycleSceneFlags[(u32)gctx->scene].chest x%08x\n", __func__,
+                       cdata.cycleSceneFlags[(u32)gctx->scene].chest);
+      gctx->actors.actor_ctx_scene_flags.chest = 0x01000000;
+
+      // gctx->actors.actor_ctx_scene_flags.chest = cdata.cycleSceneFlags[(u32)gctx->scene].chest;
       rnd::util::Print(
-          "%s: cycleSceneFlags[gctx->scene].switch1 %#08x\n gctx->actor_ctx_scene_flags.clearedRoom are %#08x\n",
-          __func__, cdata.cycleSceneFlags[(u32)gctx->scene].switch1, gctx->actor_ctx_scene_flags.clearedRoom);
+          "%s:\ncycleSceneFlags[gctx->scene].switch0 0x%08x "
+          "\ncycleSceneFlags[gctx->scene].switch1 0x%08x "
+          "\ncycleSceneFlags[gctx->scene].chest 0x%08x "
+          "\ncycleSceneFlags[gctx->scene].clearedRoom 0x%08x "
+          "\ncycleSceneFlags[gctx->scene].collectible 0x%08x "
+          "\ngctx->actor_ctx_scene_flags.switches[0] 0x%08x "
+          "\ngctx->actor_ctx_scene_flags.switches[1] 0x%08x "
+          "\ngctx->actor_ctx_scene_flags.chest 0x%08x\n",
+          __func__, cdata.cycleSceneFlags[(u32)gctx->scene].switch0, cdata.cycleSceneFlags[(u32)gctx->scene].switch1,
+          cdata.cycleSceneFlags[(u32)gctx->scene].chest, cdata.cycleSceneFlags[(u32)gctx->scene].clearedRoom,
+          cdata.cycleSceneFlags[(u32)gctx->scene].collectible, gctx->actors.actor_ctx_scene_flags.switches[0],
+          gctx->actors.actor_ctx_scene_flags.switches[1], gctx->actors.actor_ctx_scene_flags.chest);
+      util::GetPointer<void(game::GlobalContext*)>(0x18ec98)(gctx);
+      rnd::util::Print(
+          "\ngctx->actor_ctx_scene_flags.clearedRoom 0x%08x "
+          "\ngctx->actor_ctx_scene_flags.clearedRoomTemp 0x%08x "
+          "\ngctx->actor_ctx_scene_flags.collectible[0] 0x%08x "
+          "\ngctx->actor_ctx_scene_flags.collectible[1] 0x%08x "
+          "\ngctx->actor_ctx_scene_flags.collectible[2] 0x%08x "
+          "\ngctx->actor_ctx_scene_flags.switches[2] 0x%08x "
+          "\ngctx->actor_ctx_scene_flags.switches[3] 0x%08x ",
+          __func__, gctx->actors.actor_ctx_scene_flags.clearedRoom, gctx->actors.actor_ctx_scene_flags.clearedRoomTemp,
+          gctx->actors.actor_ctx_scene_flags.collectible[0], gctx->actors.actor_ctx_scene_flags.collectible[1],
+          gctx->actors.actor_ctx_scene_flags.collectible[2], gctx->actors.actor_ctx_scene_flags.collectible[3],
+          gctx->actors.actor_ctx_scene_flags.switches[2], gctx->actors.actor_ctx_scene_flags.switches[3]);
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
       auto& save = game::GetCommonData().save;
-      save.week_event_reg_93.WEEKEVENTREG_CALLED_GIANTS_ON_ROOFTOP_ONCE = 0;
-      rnd::util::Print("%s: save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED %u\n", __func__,
-                       save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED);
-      save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED = 0;
-      rnd::util::Print("%s: save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED %u\n", __func__,
-                       save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED);
+      save.inventory.woodfall_temple_keys = 0;
+      save.week_event_reg_01.WEEKEVENTREG_ENTERED_WOODFALL_TEMPLE = 0;
     }
 #endif
     if (gSettingsContext.customMaskButton != 0 && pressedButtons == gSettingsContext.customMaskButton) {

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -110,7 +110,16 @@ namespace rnd {
       gExtSaveData.givenSongChecks.songOfSoaringGiven = 0;
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
       auto& save = game::GetCommonData().save;
-      save.week_event_reg_93.WEEKEVENTREG_CALLED_GIANTS_ON_ROOFTOP_ONCE = 1;
+      save.week_event_reg_93.WEEKEVENTREG_CALLED_GIANTS_ON_ROOFTOP_ONCE = 0;
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED %u\n", __func__,
+                       save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED);
+#endif
+      save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED = 0;
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED %u\n", __func__,
+                       save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED);
+#endif
     } else if (pressedButtons == (u32)game::pad::Button::Right) {
       xPos += 10.00f;
     } else if (pressedButtons == (u32)game::pad::Button::Left) {

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -108,8 +108,9 @@ namespace rnd {
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     if (pressedButtons == (u32)game::pad::Button::ZR) {
       auto& cdata = game::GetCommonData();
-      rnd::util::Print("%s: cycleSceneFlags[gctx->scene].switch1 %08x\n", __func__,
-                       cdata.cycleSceneFlags[(u32)gctx->scene].switch1);
+      rnd::util::Print(
+          "%s: cycleSceneFlags[gctx->scene].switch1 %#08x\n gctx->actor_ctx_scene_flags.clearedRoom are %#08x\n",
+          __func__, cdata.cycleSceneFlags[(u32)gctx->scene].switch1, gctx->actor_ctx_scene_flags.clearedRoom);
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
       auto& save = game::GetCommonData().save;
       save.week_event_reg_93.WEEKEVENTREG_CALLED_GIANTS_ON_ROOFTOP_ONCE = 0;

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -107,19 +107,17 @@ namespace rnd {
 // const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     if (pressedButtons == (u32)game::pad::Button::ZR) {
-      gExtSaveData.givenSongChecks.songOfSoaringGiven = 0;
+      auto& cdata = game::GetCommonData();
+      rnd::util::Print("%s: cycleSceneFlags[gctx->scene].switch1 %08x\n", __func__,
+                       cdata.cycleSceneFlags[(u32)gctx->scene].switch1);
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
       auto& save = game::GetCommonData().save;
       save.week_event_reg_93.WEEKEVENTREG_CALLED_GIANTS_ON_ROOFTOP_ONCE = 0;
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
       rnd::util::Print("%s: save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED %u\n", __func__,
                        save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED);
-#endif
       save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED = 0;
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
       rnd::util::Print("%s: save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED %u\n", __func__,
                        save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED);
-#endif
     }
 #endif
     if (gSettingsContext.customMaskButton != 0 && pressedButtons == gSettingsContext.customMaskButton) {

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -120,14 +120,6 @@ namespace rnd {
       rnd::util::Print("%s: save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED %u\n", __func__,
                        save.week_event_reg_25.WEEKEVENTREG_OATH_CUTSCENE_SUCCEEDED);
 #endif
-    } else if (pressedButtons == (u32)game::pad::Button::Right) {
-      xPos += 10.00f;
-    } else if (pressedButtons == (u32)game::pad::Button::Left) {
-      xPos -= 10.00f;
-    } else if (pressedButtons == (u32)game::pad::Button::Up) {
-      zPos += 10.00f;
-    } else if (pressedButtons == (u32)game::pad::Button::Down) {
-      zPos -= 10.00f;
     }
 #endif
     if (gSettingsContext.customMaskButton != 0 && pressedButtons == gSettingsContext.customMaskButton) {

--- a/code/source/rnd/actors/en_giant.cpp
+++ b/code/source/rnd/actors/en_giant.cpp
@@ -1,0 +1,65 @@
+#include "rnd/actors/en_giant.h"
+
+namespace rnd {
+  extern "C" {
+  void En_Giant_ShouldDrawGiant(game::act::Actor* giant) {
+    u8 giantId = giant->params & 0xF;
+    u16 remainsCollected = Settings_CountRemainsCollected();
+    game::InventoryData::CollectRegister& collect_register = game::GetCommonData().save.inventory.collect_register;
+    if (remainsCollected >= gSettingsContext.masksNeededToEnterMoon)
+      return;  // Draw all if it's been completed.
+
+    /* XXX: This is honestly a very redunant function call, but it's here to branch
+    / out to a new function when we can implement different checks to get to the moon,
+    / like skulltulas collected, heart pieces gained, etc. */
+    switch (giantId) {
+    case 0:  // Snowhead
+      if (collect_register.gohts_remains == 0)
+        giant->draw_fn = (game::act::MainFunc*)0x0;
+      return;
+    case 1:  // Ikana
+      if (collect_register.twinmolds_remains == 0)
+        giant->draw_fn = (game::act::MainFunc*)0x0;
+      return;
+    case 2:  // Woodfall
+      if (collect_register.odolwas_remains == 0)
+        giant->draw_fn = (game::act::MainFunc*)0x0;
+      return;
+    case 3:  // Great Bay
+      if (collect_register.gyorgs_remains == 0)
+        giant->draw_fn = (game::act::MainFunc*)0x0;
+      return;
+    }
+    giant->draw_fn = (game::act::MainFunc*)0x0;
+    return;
+  }
+
+  bool En_Giant_KillAfterCutscene(game::act::Actor* giant) {
+    game::InventoryData::CollectRegister& collect_register = game::GetCommonData().save.inventory.collect_register;
+    u8 giantId = giant->params & 0xF;
+    switch (giantId) {
+    case 4:  // Snowhead
+      if (collect_register.gohts_remains == 0)
+        return false;
+      else
+        return true;
+    case 5:  // Ikana
+      if (collect_register.twinmolds_remains == 0)
+        return false;
+      else
+        return true;
+    case 6:  // Woodfall
+      if (collect_register.odolwas_remains == 0)
+        return false;
+      else
+        return true;
+    case 7:  // Great Bay
+      if (collect_register.gyorgs_remains == 0)
+        return false;
+      else
+        return true;
+    }
+    return true;
+  }
+  }
+}  // namespace rnd

--- a/code/source/rnd/actors/en_js.cpp
+++ b/code/source/rnd/actors/en_js.cpp
@@ -2,11 +2,58 @@
 
 namespace rnd
 {
-  extern "C" u16 En_Js_CheckVictoryRequirements() {
+  extern "C" {
+  u16 En_Js_CurrentMasksInInventory() {
+    // I can see why the original devs did this, because they did not want to count specific masks (transform + FD)
+    u16 count = 0;
+    if (game::HasMask(game::ItemId::MaskOfTruth))
+      count += 1;
+    if (game::HasMask(game::ItemId::KafeiMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::AllNightMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::BunnyHood))
+      count += 1;
+    if (game::HasMask(game::ItemId::KeatonMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::GaroMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::RomaniMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::CircusLeaderMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::PostmanHat))
+      count += 1;
+    if (game::HasMask(game::ItemId::CoupleMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::GreatFairyMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::GibdoMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::DonGeroMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::KamaroMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::CaptainHat))
+      count += 1;
+    if (game::HasMask(game::ItemId::StoneMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::BremenMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::BlastMask))
+      count += 1;
+    if (game::HasMask(game::ItemId::MaskOfScents))
+      count += 1;
+    if (game::HasMask(game::ItemId::GiantMask))
+      count += 1;
+    return count;
+  }
+
+  u16 En_Js_CheckVictoryRequirements() {
     auto& cdata = game::GetCommonData();
     if (cdata.save.player_form != game::act::Player::Form::Human)
       return 0x220B;
-    
+
     u16 remainsCollected = 0;
     if (cdata.save.inventory.collect_register.odolwas_remains == 1)
       remainsCollected++;
@@ -25,4 +72,5 @@ namespace rnd
     }
     return 0xFFFE;
   }
+  } 
 } // namespace rnd

--- a/code/source/rnd/actors/en_js.cpp
+++ b/code/source/rnd/actors/en_js.cpp
@@ -53,15 +53,7 @@ namespace rnd {
     if (cdata.save.player_form != game::act::Player::Form::Human)
       return 0x220B;
 
-    u16 remainsCollected = 0;
-    if (cdata.save.inventory.collect_register.odolwas_remains == 1)
-      remainsCollected++;
-    if (cdata.save.inventory.collect_register.gohts_remains == 1)
-      remainsCollected++;
-    if (cdata.save.inventory.collect_register.gyorgs_remains == 1)
-      remainsCollected++;
-    if (cdata.save.inventory.collect_register.twinmolds_remains == 1)
-      remainsCollected++;
+    u16 remainsCollected = Settings_CountRemainsCollected();
 
     if (remainsCollected >= gSettingsContext.masksNeededForVictory) {
       if (rnd::util::GetPointer<u16(int)>(0x2F217C)(0) < 20)

--- a/code/source/rnd/actors/en_js.cpp
+++ b/code/source/rnd/actors/en_js.cpp
@@ -1,7 +1,6 @@
 #include "rnd/actors/en_js.h"
 
-namespace rnd
-{
+namespace rnd {
   extern "C" {
   u16 En_Js_CurrentMasksInInventory() {
     // I can see why the original devs did this, because they did not want to count specific masks (transform + FD)
@@ -72,5 +71,5 @@ namespace rnd
     }
     return 0x6144;
   }
-  } 
-} // namespace rnd
+  }
+}  // namespace rnd

--- a/code/source/rnd/actors/en_js.cpp
+++ b/code/source/rnd/actors/en_js.cpp
@@ -70,7 +70,7 @@ namespace rnd
       else
         return 0x2202;
     }
-    return 0xFFFE;
+    return 0x6144;
   }
   } 
 } // namespace rnd

--- a/code/source/rnd/actors/en_js.cpp
+++ b/code/source/rnd/actors/en_js.cpp
@@ -1,0 +1,28 @@
+#include "rnd/actors/en_js.h"
+
+namespace rnd
+{
+  extern "C" u16 En_Js_CheckVictoryRequirements() {
+    auto& cdata = game::GetCommonData();
+    if (cdata.save.player_form != game::act::Player::Form::Human)
+      return 0x220B;
+    
+    u16 remainsCollected = 0;
+    if (cdata.save.inventory.collect_register.odolwas_remains == 1)
+      remainsCollected++;
+    if (cdata.save.inventory.collect_register.gohts_remains == 1)
+      remainsCollected++;
+    if (cdata.save.inventory.collect_register.gyorgs_remains == 1)
+      remainsCollected++;
+    if (cdata.save.inventory.collect_register.twinmolds_remains == 1)
+      remainsCollected++;
+
+    if (remainsCollected >= gSettingsContext.masksNeededForVictory) {
+      if (rnd::util::GetPointer<u16(int)>(0x2F217C)(0) < 20)
+        return 0x21FC;
+      else
+        return 0x2202;
+    }
+    return 0xFFFE;
+  }
+} // namespace rnd

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -36,7 +36,7 @@ namespace rnd {
       // Patch for the rooftop to ensure that link is not turned into a form that has unintended effects.
       cdata.save.player_form = gctx->GetPlayerActor()->active_form;
     } else if (gctx->next_entrance == 0x5401 && gSettingsContext.skipGiantsCutscene) {
-      if (CheckMoonRequirements()) {
+      if (EnFall_CheckMoonRequirements()) {
         gctx->next_entrance = 0x2C02;
         cdata.sub13s[0].entrance_index = 0x2C02;
       } else {
@@ -64,17 +64,8 @@ namespace rnd {
     cycleFlags[(u32)game::SceneId::StoneTowerTempleInverted].switch1 = 0xFFFFFFFF;
   }
 
-  bool CheckMoonRequirements() {
-    game::InventoryData::CollectRegister& collect_register = game::GetCommonData().save.inventory.collect_register;
-    u16 remainsCollected = 0;
-    if (collect_register.odolwas_remains == 1)
-      remainsCollected++;
-    if (collect_register.gohts_remains == 1)
-      remainsCollected++;
-    if (collect_register.gyorgs_remains == 1)
-      remainsCollected++;
-    if (collect_register.twinmolds_remains == 1)
-      remainsCollected++;
+  bool EnFall_CheckMoonRequirements() {
+    u16 remainsCollected = Settings_CountRemainsCollected();
 
     if (remainsCollected >= gSettingsContext.masksNeededToEnterMoon) {
       return true;

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -6,6 +6,9 @@ namespace rnd {
     game::CommonData& cdata = game::GetCommonData();
     game::GlobalContext* gctx = GetContext().gctx;
     bool didWarp = false;
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Next entrance is %#06x\n", __func__, gctx->next_entrance);
+#endif
     if (gctx->next_entrance == 0x1C04 && gSettingsContext.skipMikauCutscene) {
       gctx->next_entrance = 0x6890;
       cdata.sub13s[0].entrance_index = 0x6890;
@@ -32,6 +35,19 @@ namespace rnd {
     } else if (gctx->next_entrance == 0x2C10 && gctx->GetPlayerActor()->active_form != game::act::Player::Form::Deku) {
       // Patch for the rooftop to ensure that link is not turned into a form that has unintended effects.
       cdata.save.player_form = gctx->GetPlayerActor()->active_form;
+    } else if (gctx->next_entrance == 0x5401 && gSettingsContext.skipGiantsCutscene) {
+      if (CheckMoonRequirements()) {
+        gctx->next_entrance = 0x2C02;
+        cdata.sub13s[0].entrance_index = 0x2C02;
+      } else {
+        gctx->next_entrance = 0x2C00;
+        gctx->transitionType = 2;
+        gctx->field_C535 = 0;
+        cdata.next_cutscene_index = 0xfff2;
+        cdata.next_transition_type = 2;
+      }
+      
+      didWarp = true;
     }
 
     if (didWarp)
@@ -46,6 +62,10 @@ namespace rnd {
     cycleFlags[(u32)game::SceneId::GreatBayTemple].switch1 = 0xFFFFFFFF;
     cycleFlags[(u32)game::SceneId::StoneTowerTemple].switch1 = 0xFFFFFFFF;
     cycleFlags[(u32)game::SceneId::StoneTowerTempleInverted].switch1 = 0xFFFFFFFF;
+  }
+
+  bool CheckMoonRequirements() {
+    return true;
   }
   }
 

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -56,12 +56,23 @@ namespace rnd {
   }
 
   void ForceTempleFlags() {
-    game::PersistentSceneCycleFlags* cycleFlags = game::GetPersistentCycleStruct();
-    cycleFlags[(u32)game::SceneId::WoodfallTemple].switch1 = 0xFFFFFFFF;
-    cycleFlags[(u32)game::SceneId::SnowheadTemple].switch1 = 0xFFFFFFFF;
-    cycleFlags[(u32)game::SceneId::GreatBayTemple].switch1 = 0xFFFFFFFF;
-    cycleFlags[(u32)game::SceneId::StoneTowerTemple].switch1 = 0xFFFFFFFF;
-    cycleFlags[(u32)game::SceneId::StoneTowerTempleInverted].switch1 = 0xFFFFFFFF;
+    game::PersistentSceneCycleFlags* persistentCycleFlags = game::GetPersistentCycleStruct();
+    auto& cycleFlags = game::GetCommonData().cycleSceneFlags;
+// TODO: Make this smarter, define each fairy chest for now and door and set the switches to be properly set.
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s:\ncycleFlags[woodfall].switch0 0x%08x \ncycleFlags[woodfall].switch1 "
+                     "0x%08x \ncycleFlags[woodfall].chest 0x%08x \ncycleFlags[woodfall].clearedRoom "
+                     "0x%08x \ncycleFlags[woodfall].collectible 0x%08x \n",
+                     __func__, cycleFlags[(u32)game::SceneId::WoodfallTemple].switch0,
+                     cycleFlags[(u32)game::SceneId::WoodfallTemple].switch1,
+                     cycleFlags[(u32)game::SceneId::WoodfallTemple].clearedRoom,
+                     cycleFlags[(u32)game::SceneId::WoodfallTemple].collectible);
+#endif
+    persistentCycleFlags[(u32)game::SceneId::WoodfallTemple].chest = 0xFFFFFFFF;
+    persistentCycleFlags[(u32)game::SceneId::SnowheadTemple].switch1 = 0xFFFFFFFF;
+    persistentCycleFlags[(u32)game::SceneId::GreatBayTemple].switch1 = 0xFFFFFFFF;
+    persistentCycleFlags[(u32)game::SceneId::StoneTowerTemple].switch1 = 0xFFFFFFFF;
+    persistentCycleFlags[(u32)game::SceneId::StoneTowerTempleInverted].switch1 = 0xFFFFFFFF;
   }
 
   bool EnFall_CheckMoonRequirements() {

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -46,7 +46,7 @@ namespace rnd {
         cdata.next_cutscene_index = 0xfff2;
         cdata.next_transition_type = 2;
       }
-      
+
       didWarp = true;
     }
 

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -65,7 +65,21 @@ namespace rnd {
   }
 
   bool CheckMoonRequirements() {
-    return true;
+    game::InventoryData::CollectRegister& collect_register = game::GetCommonData().save.inventory.collect_register;
+    u16 remainsCollected = 0;
+    if (collect_register.odolwas_remains == 1)
+      remainsCollected++;
+    if (collect_register.gohts_remains == 1)
+      remainsCollected++;
+    if (collect_register.gyorgs_remains == 1)
+      remainsCollected++;
+    if (collect_register.twinmolds_remains == 1)
+      remainsCollected++;
+
+    if (remainsCollected >= gSettingsContext.masksNeededToEnterMoon) {
+      return true;
+    }
+    return false;
   }
   }
 

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -1096,10 +1096,10 @@ namespace rnd {
 
   // clang-format on
   void ItemOverride_SwapSoHAndSongGetItemText(game::GlobalContext* gctx, u16 textId, game::act::Actor* fromActor) {
-// Check which text ID is coming in. If it's any mask from Song of Healing, replace it with active item text.
-// #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-//     rnd::util::Print("%s: txtId = %#08x \n", __func__, textId);
-// #endif
+    // Check which text ID is coming in. If it's any mask from Song of Healing, replace it with active item text.
+    // #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    //     rnd::util::Print("%s: txtId = %#08x \n", __func__, textId);
+    // #endif
     if (givenItemOverride) {
       givenItemOverride = false;
       if (rStoredTextId) {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -1097,9 +1097,9 @@ namespace rnd {
   // clang-format on
   void ItemOverride_SwapSoHAndSongGetItemText(game::GlobalContext* gctx, u16 textId, game::act::Actor* fromActor) {
 // Check which text ID is coming in. If it's any mask from Song of Healing, replace it with active item text.
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s: txtId = %#08x \n", __func__, textId);
-#endif
+// #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+//     rnd::util::Print("%s: txtId = %#08x \n", __func__, textId);
+// #endif
     if (givenItemOverride) {
       givenItemOverride = false;
       if (rStoredTextId) {

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -752,11 +752,12 @@ namespace rnd {
     s32 incomingNegative = incomingGetItemId < 0;
     if (fromActor != NULL && incomingGetItemId != 0) {
       s16 getItemId = ItemOverride_CheckNpc(fromActor->id, incomingGetItemId, incomingNegative);
-#if defined ENABLE_DEBUG || DEBUG_PRINT
-      util::Print(
-          "%s: Our actor ID is %#06x\nScene is %#04x\nIncoming item id is %#04x\ngetItemId %#04x\nParams %#04x\n ",
-          __func__, fromActor->id, gctx->scene, incomingGetItemId, getItemId, fromActor->params);
-#endif
+      /*#if defined ENABLE_DEBUG || DEBUG_PRINT
+            util::Print(
+                "%s: Our actor ID is %#06x\nScene is %#04x\nIncoming item id is %#04x\ngetItemId %#04x\nParams %#04x\n
+      ",
+                __func__, fromActor->id, gctx->scene, incomingGetItemId, getItemId, fromActor->params);
+      #endif*/
       storedActorId = fromActor->id;
       storedGetItemId = incomingNegative ? (GetItemID)-incomingGetItemId : (GetItemID)incomingGetItemId;
       override = ItemOverride_Lookup(fromActor, (u16)gctx->scene, getItemId);

--- a/code/source/rnd/objects.cpp
+++ b/code/source/rnd/objects.cpp
@@ -3,9 +3,6 @@
 namespace rnd {
   ExtendedObjectContext rExtendedObjectCtx = {0};
   s32 rStoredObjId = -1;
-  s32 yPos = 0;
-  s32 xPos = 0;
-  s32 zPos = 0;
 
   // void TexAnim_Spawn(void* model, void* cmabMan) {
   //   return util::GetPointer<void(void*, void*)>(0x609c3c)(model, cmabMan);

--- a/code/source/rnd/savefile.cpp
+++ b/code/source/rnd/savefile.cpp
@@ -1007,52 +1007,6 @@ namespace rnd {
     saveData.inventory.items[slot] = firstItem;
   }
 
-  u16 CurrentMasksInInventory() {
-    // I can see why the original devs did this, because they did not want to count specific masks (transform + FD)
-    u16 count = 0;
-    if (game::HasMask(game::ItemId::MaskOfTruth))
-      count += 1;
-    if (game::HasMask(game::ItemId::KafeiMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::AllNightMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::BunnyHood))
-      count += 1;
-    if (game::HasMask(game::ItemId::KeatonMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::GaroMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::RomaniMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::CircusLeaderMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::PostmanHat))
-      count += 1;
-    if (game::HasMask(game::ItemId::CoupleMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::GreatFairyMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::GibdoMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::DonGeroMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::KamaroMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::CaptainHat))
-      count += 1;
-    if (game::HasMask(game::ItemId::StoneMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::BremenMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::BlastMask))
-      count += 1;
-    if (game::HasMask(game::ItemId::MaskOfScents))
-      count += 1;
-    if (game::HasMask(game::ItemId::GiantMask))
-      count += 1;
-    return count;
-  }
-
   void SaveFile_UpdateBossExtData() {
     game::SceneId scene = GetContext().gctx->scene;
     switch (scene) {

--- a/code/source/rnd/settings.cpp
+++ b/code/source/rnd/settings.cpp
@@ -54,6 +54,21 @@ namespace rnd {
 
     return modifiedChangeHealth;
   }
+
+  u16 Settings_CountRemainsCollected() {
+    game::InventoryData::CollectRegister& collect_register = game::GetCommonData().save.inventory.collect_register;
+    u16 remainsCollected = 0;
+    if (collect_register.odolwas_remains == 1)
+      remainsCollected++;
+    if (collect_register.gohts_remains == 1)
+      remainsCollected++;
+    if (collect_register.gyorgs_remains == 1)
+      remainsCollected++;
+    if (collect_register.twinmolds_remains == 1)
+      remainsCollected++;
+
+    return remainsCollected;
+  }
   // With the No Health Refill option on, full health refills from health upgrades and Bombchu
   // Bowling are turned off, and fairies restore 3 hearts Otherwise, they grant a full heal, and the
   // default effect applies (full heal from bottle, 8 hearts on contact)


### PR DESCRIPTION
Two new options have been included in settings for app side. `masksNeededToEnterMoon` and `masksNeededForVictory`. The latter could be a temporary setting as we look into more victory conditions and increase complexity on this check, but for now we can adjust the remains from 1-4 for each check, allowing for earlier moon checks.

This change also includes a new option to skip the Giant's Cutscene when Oath to Order is played (`skipGiantsCutscene`). 

The clock tower text generated on the app side should include how many masks are required to get to the Moon, while the new text ID (`0x6144`) should include how many remains are required if the requirements are not yet met. The Moon Child also remains to have default behaviour to take off any mask before talking to him.

Adjusts Giant's Cutscene to ensure that 4 Giants are showing if we have met requirements, otherwise it will show the amount that you have for the remains you acquired.