### PR TITLE
fix: Update Cycle Reset Dungeon Issues

### DIFF
--- a/code/include/rnd/actors/en_elforg.h
+++ b/code/include/rnd/actors/en_elforg.h
@@ -37,7 +37,7 @@ namespace rnd {
   s32 En_Elforg_OverrideModelDraw(game::act::sa_unk_d4*, game::act::Actor*);
   void En_Elforg_UpdateExtFairyBits(game::act::Actor*, game::GlobalContext*);
   bool En_Elforg_Chest_IsFairyObtained(u32 param, game::GlobalContext*);
-  } 
+  }
   void En_Elforg_Destroy(game::act::Actor*, game::GlobalContext*);
 
 }  // namespace rnd

--- a/code/include/rnd/actors/en_elforg.h
+++ b/code/include/rnd/actors/en_elforg.h
@@ -1,0 +1,39 @@
+#ifndef _RND_ACTORS_EN_ELFORG_H_
+#define _RND_ACTORS_EN_ELFORG_H_
+
+#include "game/actor.h"
+#include "game/as.h"
+#include "game/collision.h"
+#include "rnd/models.h"
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#include "common/debug.h"
+extern "C" {
+#include <3ds/svc.h>
+}
+#endif
+namespace rnd {
+  struct En_Elforg : public game::act::Actor {
+    game::as::ActorUtil actor_util;
+    u8 gap_284[336];
+    z3d_nn_math_MTX34 some_mtx;
+    u8 gap_404[528];
+    game::CollisionInfoCylinder collider;
+    u8 gap_664[8];
+    game::act::Actor* attached_enemy;
+    u16 strayFairyFlags;
+    s16 direction;
+    u8 gap_674[4];
+    s32 timer;
+    float secondaryTimer;
+    float targetSpeedXZ;
+    float targetDistanceFromHome;
+    void* next_fn;
+    u32 field_68C;
+  };
+  static_assert(sizeof(En_Elforg) == 0x690);
+  void En_Elforg_Init(game::act::Actor* actor, game::GlobalContext* gctx);
+  extern "C" s32 En_Elforg_OverrideModelDraw(game::act::sa_unk_d4*, game::act::Actor*);
+  void En_Elforg_Destroy(game::act::Actor* actor, game::GlobalContext* gctx);
+
+}  // namespace rnd
+#endif

--- a/code/include/rnd/actors/en_elforg.h
+++ b/code/include/rnd/actors/en_elforg.h
@@ -31,9 +31,14 @@ namespace rnd {
     u32 field_68C;
   };
   static_assert(sizeof(En_Elforg) == 0x690);
-  void En_Elforg_Init(game::act::Actor* actor, game::GlobalContext* gctx);
-  extern "C" s32 En_Elforg_OverrideModelDraw(game::act::sa_unk_d4*, game::act::Actor*);
-  void En_Elforg_Destroy(game::act::Actor* actor, game::GlobalContext* gctx);
+  int En_Elforg_getFairyIndex(game::SceneId);
+  void En_Elforg_Init(game::act::Actor*, game::GlobalContext*);
+  extern "C" {
+  s32 En_Elforg_OverrideModelDraw(game::act::sa_unk_d4*, game::act::Actor*);
+  void En_Elforg_UpdateExtFairyBits(game::act::Actor*, game::GlobalContext*);
+  bool En_Elforg_Chest_IsFairyObtained(u32 param, game::GlobalContext*);
+  } 
+  void En_Elforg_Destroy(game::act::Actor*, game::GlobalContext*);
 
 }  // namespace rnd
 #endif

--- a/code/include/rnd/item_override.h
+++ b/code/include/rnd/item_override.h
@@ -235,6 +235,7 @@ namespace rnd {
     /* 0xB8 */ GI_MAP_OF_GREAT_BAY,
     /* 0xB9 */ GI_MAP_OF_STONE_TOWER,
     /* 0xBA */ GI_FISHING_HOLE_PASS,
+    /* 0xBB */ GI_CUSTOM_STRAY_FAIRY,
   };
 
   enum class DrawGraphicItemID : s32 {

--- a/code/include/rnd/savefile.h
+++ b/code/include/rnd/savefile.h
@@ -8,7 +8,7 @@
 #include "z3d/z3DVec.h"
 
 // Increment the version number whenever the ExtSaveData structure is changed
-#define EXTSAVEDATA_VERSION 18
+#define EXTSAVEDATA_VERSION 19
 #define SAVEFILE_SCENES_DISCOVERED_IDX_COUNT 4
 #define SAVEFILE_SPOILER_ITEM_MAX 512
 
@@ -153,6 +153,7 @@ namespace rnd {
     u8 itemCollected[SAVEFILE_SPOILER_ITEM_MAX];
     u8 chestRewarded[116][32];  // Reward table that's stored by scene and chest param/flag.
     game::ItemId collectedTradeItems[9];
+    u32 dungeonFairyBitfields[4];
   } ExtSaveData;
 
   extern "C" ExtSaveData gExtSaveData;

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -369,6 +369,10 @@ SECTIONS{
     *(.patch_LullabyCheckEnJg)
   }
 
+  .patch_EnElforgUpdateFairyBits 0x25A69C : {
+    *(.patch_EnElforgUpdateFairyBits)
+  }
+
   .patch_EnOsnCheckSoHExtData 0x268030 : {
     *(.patch_EnOsnCheckSoHExtData)
   }
@@ -557,6 +561,10 @@ SECTIONS{
 
   .patch_RemainsModelDraw 0x3C7D7C : {
     *(.patch_RemainsModelDraw)
+  }
+
+  .patch_EnElfOrgTreasureSwitchSet 0x3CDDEC : {
+    *(.patch_EnElfOrgTreasureSwitchSet)
   }
 
   .patch_TingleCheckClocktownMapTwo 0x3F5F00 : {
@@ -750,6 +758,10 @@ SECTIONS{
 
   .patch_EnGkCheckLullabyRewardGiven 0x546294 : {
     *(.patch_EnGkCheckLullabyRewardGiven)
+  }
+
+  .patch_EnBoxCheckIfFairyObtained 0x5758E0 : {
+    *(.patch_EnBoxCheckIfFairyObtained)
   }
 
   .patch_AdjustMoonEntryRequirements 0x576D48 : {

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -667,10 +667,6 @@ SECTIONS{
     *(.patch_DmChar05GoronDraw)
   } */
 
-  /* .patch_tmp 0x41d224 : {
-    *(.patch_tmp)
-  } */
-
   .patch_GibdoMaskGiveItem 0x41DC48 : {
     *(.patch_GibdoMaskGiveItem)
   }

--- a/code/source/asm/fairy_hooks.s
+++ b/code/source/asm/fairy_hooks.s
@@ -5,6 +5,16 @@
 .rActiveItemRow_addr:
     .word rActiveItemRow
 
+.global hook_EnElforgUpdateFairyBits
+hook_EnElforgUpdateFairyBits:
+    push {r0-r12, lr}
+    cpy r0, r4 @actor
+    cpy r1,r8 @gctx
+    bl En_Elforg_UpdateExtFairyBits
+    pop {r0-r12, lr}
+    ldrsh r0,[r4,#0x1C]
+    bx lr
+
 .global hook_OverrideFairyItem
 hook_OverrideFairyItem:
     push {r0-r12, lr}
@@ -27,3 +37,25 @@ hook_OverrideFairyItem:
 noOverrideFairyItemID:
     cpy r0,r4
     b 0x3becf4
+
+.global hook_EnElforgUpdateFairyBitsTwo
+hook_EnElforgUpdateFairyBitsTwo:
+    push {r0-r12, lr}
+    cpy r0, r4 @actor
+    cpy r1,r8 @gctx
+    bl En_Elforg_UpdateExtFairyBits
+    pop {r0-r12, lr}
+    cpy r0,r8
+    bx lr
+
+.global hook_EnBoxCheckIfFairyObtained
+hook_EnBoxCheckIfFairyObtained:
+    orr r1,r3,r1, lsl #0x9
+    push {r0-r12, lr}
+    cpy r0,r1 @param
+    cpy r1,r5 @gctx
+    bl En_Elforg_Chest_IsFairyObtained
+    cmp r0, #0x1
+    pop {r0-r12,lr}
+    beq 0x575908
+    bx lr

--- a/code/source/asm/fairy_patches.s
+++ b/code/source/asm/fairy_patches.s
@@ -1,5 +1,10 @@
 .arm
 
+.section .patch_EnElforgUpdateFairyBits
+.global patch_EnElforgUpdateFairyBits
+patch_EnElforgUpdateFairyBits:
+    bl hook_EnElforgUpdateFairyBits
+
 .section .patch_OverrideFairyGiveItem
 .global OverrideFairyItemID_patch
 OverrideFairyItemID_patch:
@@ -12,3 +17,15 @@ OverrideGreatFairySpawn_patch:
     @ldmia sp!,{r4 - r6, pc}
     @ldmia sp !, {r4 - r6, lr}
     @ bx lr
+
+.section .patch_EnElfOrgTreasureSwitchSet
+.global patch_EnElfOrgTreasureSwitchSet
+patch_EnElfOrgTreasureSwitchSet:
+    bl hook_EnElforgUpdateFairyBitsTwo
+
+
+@TODO: Break out Chest patches into separate chest file.
+.section .patch_EnBoxCheckIfFairyObtained
+.global patch_EnBoxCheckIfFairyObtained
+patch_EnBoxCheckIfFairyObtained:
+    bl hook_EnBoxCheckIfFairyObtained

--- a/code/source/asm/patches.s
+++ b/code/source/asm/patches.s
@@ -83,11 +83,6 @@ patch_KeepBowOnEpona:
 patch_RemoveMysteryMilkTimer:
     nop
 
-.section .patch_tmp
-.global patch_tmp
-patch_tmp:
-    b 0x34EA0C
-
 @ Skips past a loop that resets all
 @ values in the each dungeon for 
 @ keys/fairies/boss key/etc

--- a/code/source/main.cpp
+++ b/code/source/main.cpp
@@ -107,38 +107,7 @@ namespace rnd {
 // const u32 newButtons = gctx->pad_state.input.new_buttons.flags;
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
     if (pressedButtons == (u32)game::pad::Button::ZR) {
-      auto& cdata = game::GetCommonData();
-      rnd::util::Print("%s: cdata.cycleSceneFlags[(u32)gctx->scene].chest x%08x\n", __func__,
-                       cdata.cycleSceneFlags[(u32)gctx->scene].chest);
-      gctx->actors.actor_ctx_scene_flags.chest = 0x01000000;
-
-      // gctx->actors.actor_ctx_scene_flags.chest = cdata.cycleSceneFlags[(u32)gctx->scene].chest;
-      rnd::util::Print(
-          "%s:\ncycleSceneFlags[gctx->scene].switch0 0x%08x "
-          "\ncycleSceneFlags[gctx->scene].switch1 0x%08x "
-          "\ncycleSceneFlags[gctx->scene].chest 0x%08x "
-          "\ncycleSceneFlags[gctx->scene].clearedRoom 0x%08x "
-          "\ncycleSceneFlags[gctx->scene].collectible 0x%08x "
-          "\ngctx->actor_ctx_scene_flags.switches[0] 0x%08x "
-          "\ngctx->actor_ctx_scene_flags.switches[1] 0x%08x "
-          "\ngctx->actor_ctx_scene_flags.chest 0x%08x\n",
-          __func__, cdata.cycleSceneFlags[(u32)gctx->scene].switch0, cdata.cycleSceneFlags[(u32)gctx->scene].switch1,
-          cdata.cycleSceneFlags[(u32)gctx->scene].chest, cdata.cycleSceneFlags[(u32)gctx->scene].clearedRoom,
-          cdata.cycleSceneFlags[(u32)gctx->scene].collectible, gctx->actors.actor_ctx_scene_flags.switches[0],
-          gctx->actors.actor_ctx_scene_flags.switches[1], gctx->actors.actor_ctx_scene_flags.chest);
-      util::GetPointer<void(game::GlobalContext*)>(0x18ec98)(gctx);
-      rnd::util::Print(
-          "\ngctx->actor_ctx_scene_flags.clearedRoom 0x%08x "
-          "\ngctx->actor_ctx_scene_flags.clearedRoomTemp 0x%08x "
-          "\ngctx->actor_ctx_scene_flags.collectible[0] 0x%08x "
-          "\ngctx->actor_ctx_scene_flags.collectible[1] 0x%08x "
-          "\ngctx->actor_ctx_scene_flags.collectible[2] 0x%08x "
-          "\ngctx->actor_ctx_scene_flags.switches[2] 0x%08x "
-          "\ngctx->actor_ctx_scene_flags.switches[3] 0x%08x ",
-          __func__, gctx->actors.actor_ctx_scene_flags.clearedRoom, gctx->actors.actor_ctx_scene_flags.clearedRoomTemp,
-          gctx->actors.actor_ctx_scene_flags.collectible[0], gctx->actors.actor_ctx_scene_flags.collectible[1],
-          gctx->actors.actor_ctx_scene_flags.collectible[2], gctx->actors.actor_ctx_scene_flags.collectible[3],
-          gctx->actors.actor_ctx_scene_flags.switches[2], gctx->actors.actor_ctx_scene_flags.switches[3]);
+      util::Print("%s: Hehe :)", __func__);
     } else if (pressedButtons == (u32)game::pad::Button::ZL) {
       auto& save = game::GetCommonData().save;
       save.inventory.woodfall_temple_keys = 0;

--- a/code/source/rnd/actors/en_elforg.cpp
+++ b/code/source/rnd/actors/en_elforg.cpp
@@ -1,14 +1,103 @@
 #include "rnd/actors/en_elforg.h"
 
 namespace rnd {
-  void En_Elforg_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
-    util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x3CD9D0)(actor, gctx);
-    Model_SpawnByActor(actor, gctx, 0xBB);
+  int En_Elforg_getFairyIndex(game::SceneId scene) {
+    switch (scene) {
+    case game::SceneId::WoodfallTemple:
+      return 0;
+      break;
+    case game::SceneId::SnowheadTemple:
+      return 1;
+      break;
+    case game::SceneId::GreatBayTemple:
+      return 2;
+    case game::SceneId::StoneTowerTemple:
+    case game::SceneId::StoneTowerTempleInverted:
+      return 3;
+    default:
+      return -1;
+    }
   }
 
-  extern "C" s32 En_Elforg_OverrideModelDraw(game::act::sa_unk_d4* saModel, game::act::Actor* actor) {
+  void En_Elforg_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
+    int fairyType = actor->params & 0xF;
+    int bitIndex = ((actor->params << 0x10) >> 0x19);
+    int fairyIdx = En_Elforg_getFairyIndex(gctx->scene);
+    bool isFlagSet = (gExtSaveData.dungeonFairyBitfields[fairyIdx] & 1 << (bitIndex & 0x1F));
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Fairy index is %u bit index is %#04x fairy type is %#04x and are we set? %u\n", __func__,
+                     fairyIdx, bitIndex, fairyType, isFlagSet);
+#endif
+    if (fairyIdx != -1) {
+      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+        rnd::util::Print("%s: Fairy type is %u\n", __func__, fairyType);	
+      #endif
+      switch (fairyType) {
+      default:  // Regular switch flag
+        if (isFlagSet)
+          util::GetPointer<void(game::GlobalContext*, int)>(0x4C6D70)(gctx, bitIndex);
+        break;
+      case 1:
+      case 2:
+      case 3:
+      case 8:
+        break;
+      case 6:  // Treasure flag
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+          rnd::util::Print("%s: CASE 6, LOOKING AT FLAG SET?\n", __func__);	
+#endif
+        if (isFlagSet) {
+          util::GetPointer<void(game::GlobalContext*, int)>(0x4C6D58)(gctx, bitIndex);  // Set Treasure
+          #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+          rnd::util::Print("%s: Set treasure bit, flag was true %u bitIdx is %#04x\n", __func__,
+                           (gExtSaveData.dungeonFairyBitfields[fairyIdx] & 1 << (bitIndex & 0x1F)), bitIndex);
+#endif
+        }
+
+        break;
+      case 7:  // Collectible flag
+        if (isFlagSet) {
+          util::GetPointer<void(game::GlobalContext*, int)>(0x494BD4)(gctx, bitIndex);  // Set Collectible
+        }
+
+        break;
+      }
+    }
+
+    util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x3CD9D0)(actor, gctx);
+    // Model_SpawnByActor(actor, gctx, 0xBB);
+  }
+
+  extern "C" {
+  void En_Elforg_UpdateExtFairyBits(game::act::Actor* actor, game::GlobalContext* gctx) {
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: SETTTTTTTING\n", __func__);
+#endif
+    int bitIndex = ((actor->params << 0x10) >> 0x19);
+    int fairyIdx = En_Elforg_getFairyIndex(gctx->scene);
+    if (fairyIdx != -1) {
+
+      gExtSaveData.dungeonFairyBitfields[fairyIdx] |= 1 << (bitIndex & 0x1F);
+    }
+    return;
+  }
+  s32 En_Elforg_OverrideModelDraw(game::act::sa_unk_d4* saModel, game::act::Actor* actor) {
     return Model_DrawByActor(actor, &saModel->mtx);
   }
+
+  bool En_Elforg_Chest_IsFairyObtained(u32 param, game::GlobalContext* gctx) {
+    int bitIndex = ((param << 0x10) >> 0x19);
+    int fairyIdx = En_Elforg_getFairyIndex(gctx->scene);
+    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+    rnd::util::Print("%s: Fair idx %u bitfield is %#08x\n", __func__, fairyIdx,
+                     (gExtSaveData.dungeonFairyBitfields[fairyIdx] & 1 << (bitIndex & 0x1F)));
+#endif
+    if (fairyIdx != -1)
+      return (gExtSaveData.dungeonFairyBitfields[fairyIdx] & 1 << (bitIndex & 0x1F));
+    return false;
+  }
+  }
+  
 
   void En_Elforg_Destroy(game::act::Actor* self, game::GlobalContext*) {
     Model_DestroyByActor(self);

--- a/code/source/rnd/actors/en_elforg.cpp
+++ b/code/source/rnd/actors/en_elforg.cpp
@@ -1,0 +1,18 @@
+#include "rnd/actors/en_elforg.h"
+
+namespace rnd {
+  void En_Elforg_Init(game::act::Actor* actor, game::GlobalContext* gctx) {
+    util::GetPointer<void(game::act::Actor*, game::GlobalContext*)>(0x3CD9D0)(actor, gctx);
+    Model_SpawnByActor(actor, gctx, 0xBB);
+  }
+
+  extern "C" s32 En_Elforg_OverrideModelDraw(game::act::sa_unk_d4* saModel, game::act::Actor* actor) {
+    return Model_DrawByActor(actor, &saModel->mtx);
+  }
+
+  void En_Elforg_Destroy(game::act::Actor* self, game::GlobalContext*) {
+    Model_DestroyByActor(self);
+    util::GetPointer<void(game::act::Actor*)>(0x3CDF20)(self);
+  }
+
+}  // namespace rnd

--- a/code/source/rnd/actors/en_elforg.cpp
+++ b/code/source/rnd/actors/en_elforg.cpp
@@ -29,9 +29,9 @@ namespace rnd {
                      fairyIdx, bitIndex, fairyType, isFlagSet);
 #endif
     if (fairyIdx != -1) {
-      #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-        rnd::util::Print("%s: Fairy type is %u\n", __func__, fairyType);	
-      #endif
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
+      rnd::util::Print("%s: Fairy type is %u\n", __func__, fairyType);
+#endif
       switch (fairyType) {
       default:  // Regular switch flag
         if (isFlagSet)
@@ -44,11 +44,11 @@ namespace rnd {
         break;
       case 6:  // Treasure flag
 #if defined ENABLE_DEBUG || defined DEBUG_PRINT
-          rnd::util::Print("%s: CASE 6, LOOKING AT FLAG SET?\n", __func__);	
+        rnd::util::Print("%s: CASE 6, LOOKING AT FLAG SET?\n", __func__);
 #endif
         if (isFlagSet) {
           util::GetPointer<void(game::GlobalContext*, int)>(0x4C6D58)(gctx, bitIndex);  // Set Treasure
-          #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
           rnd::util::Print("%s: Set treasure bit, flag was true %u bitIdx is %#04x\n", __func__,
                            (gExtSaveData.dungeonFairyBitfields[fairyIdx] & 1 << (bitIndex & 0x1F)), bitIndex);
 #endif
@@ -76,7 +76,6 @@ namespace rnd {
     int bitIndex = ((actor->params << 0x10) >> 0x19);
     int fairyIdx = En_Elforg_getFairyIndex(gctx->scene);
     if (fairyIdx != -1) {
-
       gExtSaveData.dungeonFairyBitfields[fairyIdx] |= 1 << (bitIndex & 0x1F);
     }
     return;
@@ -88,7 +87,7 @@ namespace rnd {
   bool En_Elforg_Chest_IsFairyObtained(u32 param, game::GlobalContext* gctx) {
     int bitIndex = ((param << 0x10) >> 0x19);
     int fairyIdx = En_Elforg_getFairyIndex(gctx->scene);
-    #if defined ENABLE_DEBUG || defined DEBUG_PRINT
+#if defined ENABLE_DEBUG || defined DEBUG_PRINT
     rnd::util::Print("%s: Fair idx %u bitfield is %#08x\n", __func__, fairyIdx,
                      (gExtSaveData.dungeonFairyBitfields[fairyIdx] & 1 << (bitIndex & 0x1F)));
 #endif
@@ -97,7 +96,6 @@ namespace rnd {
     return false;
   }
   }
-  
 
   void En_Elforg_Destroy(game::act::Actor* self, game::GlobalContext*) {
     Model_DestroyByActor(self);

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -57,22 +57,12 @@ namespace rnd {
 
   void ForceTempleFlags() {
     game::PersistentSceneCycleFlags* persistentCycleFlags = game::GetPersistentCycleStruct();
-    auto& cycleFlags = game::GetCommonData().cycleSceneFlags;
-// TODO: Make this smarter, define each fairy chest for now and door and set the switches to be properly set.
-#if defined ENABLE_DEBUG || defined DEBUG_PRINT
-    rnd::util::Print("%s:\ncycleFlags[woodfall].switch0 0x%08x \ncycleFlags[woodfall].switch1 "
-                     "0x%08x \ncycleFlags[woodfall].chest 0x%08x \ncycleFlags[woodfall].clearedRoom "
-                     "0x%08x \ncycleFlags[woodfall].collectible 0x%08x \n",
-                     __func__, cycleFlags[(u32)game::SceneId::WoodfallTemple].switch0,
-                     cycleFlags[(u32)game::SceneId::WoodfallTemple].switch1,
-                     cycleFlags[(u32)game::SceneId::WoodfallTemple].clearedRoom,
-                     cycleFlags[(u32)game::SceneId::WoodfallTemple].collectible);
-#endif
-    persistentCycleFlags[(u32)game::SceneId::WoodfallTemple].chest = 0xFFFFFFFF;
-    persistentCycleFlags[(u32)game::SceneId::SnowheadTemple].switch1 = 0xFFFFFFFF;
-    persistentCycleFlags[(u32)game::SceneId::GreatBayTemple].switch1 = 0xFFFFFFFF;
-    persistentCycleFlags[(u32)game::SceneId::StoneTowerTemple].switch1 = 0xFFFFFFFF;
-    persistentCycleFlags[(u32)game::SceneId::StoneTowerTempleInverted].switch1 = 0xFFFFFFFF;
+    // Ensure persistent cycle flags do not reset doors. Bits are commonly stored in highest bit except for inverted.
+    persistentCycleFlags[(u32)game::SceneId::WoodfallTemple].switch1 = 0xF0000000; // Highest bit is the door
+    persistentCycleFlags[(u32)game::SceneId::SnowheadTemple].switch1 = 0xF0000000;
+    persistentCycleFlags[(u32)game::SceneId::GreatBayTemple].switch1 = 0xF0000000;
+    persistentCycleFlags[(u32)game::SceneId::StoneTowerTemple].switch1 = 0xF0000000;
+    persistentCycleFlags[(u32)game::SceneId::StoneTowerTempleInverted].switch1 = 0xFF000000;
   }
 
   bool EnFall_CheckMoonRequirements() {

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -58,7 +58,7 @@ namespace rnd {
   void ForceTempleFlags() {
     game::PersistentSceneCycleFlags* persistentCycleFlags = game::GetPersistentCycleStruct();
     // Ensure persistent cycle flags do not reset doors. Bits are commonly stored in highest bit except for inverted.
-    persistentCycleFlags[(u32)game::SceneId::WoodfallTemple].switch1 = 0xF0000000; // Highest bit is the door
+    persistentCycleFlags[(u32)game::SceneId::WoodfallTemple].switch1 = 0xF0000000;  // Highest bit is the door
     persistentCycleFlags[(u32)game::SceneId::SnowheadTemple].switch1 = 0xF0000000;
     persistentCycleFlags[(u32)game::SceneId::GreatBayTemple].switch1 = 0xF0000000;
     persistentCycleFlags[(u32)game::SceneId::StoneTowerTemple].switch1 = 0xF0000000;

--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -2,6 +2,7 @@
 #include "rnd/actors/dm_char03.h"
 #include "rnd/actors/dm_char05.h"
 #include "rnd/actors/dm_hina.h"
+#include "rnd/actors/en_elforg.h"
 #include "rnd/actors/en_mag.h"
 #include "rnd/actors/en_si.h"
 #include "rnd/actors/fish_heart.h"
@@ -349,6 +350,8 @@ namespace rnd {
 
     overlayTable[0x12D].info->init_fn = Dm_Char05_Init;
     overlayTable[0x12D].info->deinit_fn = Dm_Char05_Destroy;
+
+    overlayTable[0x145].info->init_fn = En_Elforg_Init;
 
     overlayTable[0x16A].info->init_fn = Fish_Heart_Init;
     overlayTable[0x16A].info->deinit_fn = Fish_Heart_Destroy;


### PR DESCRIPTION
This PR includes changes to stray fairies and cycle scene flags in dungeons. This is mainly some cleanup within the global context structure, as well as some additions to the actor context. 

From now on, stray fairies will no longer spawn after being collected, enemies that drop fairies will no longer drop fairies, and chests will be empty when opening them after a cycle reset.

Events and switches within temples should also be reset (i.e. the pillar in snowhead will reset, the chests will have to be respawned from eye switches). 