### PR TITLE
fix: Adjust Moon Transportation When Requirements not Met

### DIFF
--- a/code/include/rnd/actors/obj_warpstone.h
+++ b/code/include/rnd/actors/obj_warpstone.h
@@ -2,6 +2,8 @@
 
 #include "game/actor.h"
 #include "game/collision.h"
+#include "game/items.h"
+#include "rnd/settings.h"
 
 namespace rnd {
 
@@ -20,7 +22,7 @@ namespace rnd {
     ObjectSekModels modelIndex;
     u8 save_status;
     void* calc_fn;
-    game::act::sa_unk_d4 skelAnime;
+    game::act::sa_unk_d4* skelAnime;
     u32 field_270;
     u32 field_274;
     u16 field_278;
@@ -34,4 +36,7 @@ namespace rnd {
     u8 ex_started_activating;
     u16 field_28E;
   };
+  static_assert(sizeof(Obj_Warpstone) == 0x290);
+
+  extern "C" void Obj_Warpstone_ExitMoon(game::GlobalContext*, u16);
 }  // namespace rnd

--- a/code/include/rnd/actors/obj_warpstone.h
+++ b/code/include/rnd/actors/obj_warpstone.h
@@ -4,6 +4,12 @@
 #include "game/collision.h"
 
 namespace rnd {
+
+  typedef enum {
+    /* 0 */ SEK_MODEL_CLOSED,
+    /* 1 */ SEK_MODEL_OPENED
+  } ObjectSekModels;
+
   struct Obj_Warpstone : public game::act::Actor {
     u8 gap_1F8[8];
     u32 field_200;
@@ -11,7 +17,7 @@ namespace rnd {
     game::CollisionBodyCylinder col_body;
     u8 talking;
     u8 timer;
-    u8 field_266;
+    ObjectSekModels modelIndex;
     u8 save_status;
     void* calc_fn;
     game::act::sa_unk_d4 skelAnime;
@@ -28,4 +34,4 @@ namespace rnd {
     u8 ex_started_activating;
     u16 field_28E;
   };
-} // namespace rnd 
+}  // namespace rnd

--- a/code/include/rnd/actors/obj_warpstone.h
+++ b/code/include/rnd/actors/obj_warpstone.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "game/actor.h"
+#include "game/collision.h"
+
+namespace rnd {
+  struct Obj_Warpstone : public game::act::Actor {
+    u8 gap_1F8[8];
+    u32 field_200;
+    u8 gap_204[8];
+    game::CollisionBodyCylinder col_body;
+    u8 talking;
+    u8 timer;
+    u8 field_266;
+    u8 save_status;
+    void* calc_fn;
+    game::act::sa_unk_d4 skelAnime;
+    u32 field_270;
+    u32 field_274;
+    u16 field_278;
+    u16 field_27A;
+    u16 timer2;
+    u8 gap_27E[2];
+    u32 field_280;
+    u32 field_284;
+    u32 field_288;
+    u8 activating;
+    u8 ex_started_activating;
+    u16 field_28E;
+  };
+} // namespace rnd 

--- a/code/include/rnd/settings.h
+++ b/code/include/rnd/settings.h
@@ -448,7 +448,8 @@ namespace rnd {
   extern const char hashIconNames[62][25];
 
   extern "C" s32 Settings_ApplyDamageMultiplier(game::GlobalContext*, s32);
-  u16 Settings_CountRemainsCollected();
+  bool Settings_MetMoonRequirements();
+  bool Settings_MetVictoryRequirements();
   u32 Hash(u32);
   u8 Bias(u32);
 }  // namespace rnd

--- a/code/mm.ld
+++ b/code/mm.ld
@@ -503,6 +503,12 @@ SECTIONS{
     *(.patch_SaveExtDataOnOwl)
   }
 
+  /*We do not want to intersect with ext saves for moon edge cases.
+  * So we will make a separate patch an instruction down.*/
+  .patch_ObjWarpstoneExitMoon 0x317030 : {
+    *(.patch_ObjWarpstoneExitMoon)
+  }
+
   .patch_IceArrowsAnywhere 0x31874C : {
     *(.patch_IceArrowsAnywhere)
   }

--- a/code/source/asm/actors/obj_warpstone_hooks.s
+++ b/code/source/asm/actors/obj_warpstone_hooks.s
@@ -1,0 +1,11 @@
+.arm
+.text
+
+.global hook_ObjWarpstoneExitMoon
+hook_ObjWarpstoneExitMoon:
+  push {r0-r12, lr}
+  cpy r0,r6
+  bl Obj_Warpstone_ExitMoon
+  pop {r0-r12, lr}
+  strb r2,[r4,#0x51e]
+  bx lr

--- a/code/source/asm/actors/obj_warpstone_patches.s
+++ b/code/source/asm/actors/obj_warpstone_patches.s
@@ -1,0 +1,6 @@
+.arm
+
+.section .patch_ObjWarpstoneExitMoon
+.global patch_ObjWarpstoneExitMoon
+patch_ObjWarpstoneExitMoon:
+  bl hook_ObjWarpstoneExitMoon

--- a/code/source/rnd/actors/en_giant.cpp
+++ b/code/source/rnd/actors/en_giant.cpp
@@ -4,10 +4,9 @@ namespace rnd {
   extern "C" {
   void En_Giant_ShouldDrawGiant(game::act::Actor* giant) {
     u8 giantId = giant->params & 0xF;
-    u16 remainsCollected = Settings_CountRemainsCollected();
     game::SaveData save = game::GetCommonData().save;
     game::InventoryData::CollectRegister& collect_register = save.inventory.collect_register;
-    if (remainsCollected >= gSettingsContext.masksNeededToEnterMoon)
+    if (Settings_MetMoonRequirements())
       return;  // Draw all if it's been completed.
 
     /* XXX: This is honestly a very redunant function call, but it's here to branch

--- a/code/source/rnd/actors/en_js.cpp
+++ b/code/source/rnd/actors/en_js.cpp
@@ -53,9 +53,7 @@ namespace rnd {
     if (cdata.save.player_form != game::act::Player::Form::Human)
       return 0x220B;
 
-    u16 remainsCollected = Settings_CountRemainsCollected();
-
-    if (remainsCollected >= gSettingsContext.masksNeededForVictory) {
+    if (Settings_MetVictoryRequirements()) {
       if (rnd::util::GetPointer<u16(int)>(0x2F217C)(0) < 20)
         return 0x21FC;
       else

--- a/code/source/rnd/actors/obj_warpstone.cpp
+++ b/code/source/rnd/actors/obj_warpstone.cpp
@@ -1,0 +1,1 @@
+#include "rnd/actors/obj_warpstone.h"

--- a/code/source/rnd/actors/obj_warpstone.cpp
+++ b/code/source/rnd/actors/obj_warpstone.cpp
@@ -1,1 +1,18 @@
 #include "rnd/actors/obj_warpstone.h"
+
+namespace rnd {
+  extern "C" void Obj_Warpstone_ExitMoon(game::GlobalContext* gctx, u16 sceneNum) {
+    if (sceneNum == 0xC810) {
+      game::CommonData& cdata = game::GetCommonData();
+
+      if (game::HasItem(game::ItemId::SongOfTime) || Settings_MetVictoryRequirements())
+        return;
+      gctx->next_entrance = 0xD8B0;
+      cdata.sub13s[0].entrance_index = 0xD8B0;
+      cdata.sub1.field_1C = static_cast<int>(game::SceneId::SouthClockTown);
+      cdata.sub1.save_entrance = 0xD8B0;
+      gctx->field_C529_one_to_clear_input = 0x14;
+      return;
+    }
+  }
+} // namespace rnd 

--- a/code/source/rnd/custom_entrances.cpp
+++ b/code/source/rnd/custom_entrances.cpp
@@ -66,9 +66,7 @@ namespace rnd {
   }
 
   bool EnFall_CheckMoonRequirements() {
-    u16 remainsCollected = Settings_CountRemainsCollected();
-
-    if (remainsCollected >= gSettingsContext.masksNeededToEnterMoon) {
+    if (Settings_MetMoonRequirements()) {
       return true;
     }
     return false;

--- a/code/source/rnd/settings.cpp
+++ b/code/source/rnd/settings.cpp
@@ -69,6 +69,17 @@ namespace rnd {
 
     return remainsCollected;
   }
+
+  bool Settings_MetMoonRequirements() {
+    u16 remainsCollected = Settings_CountRemainsCollected();
+    return remainsCollected >= gSettingsContext.masksNeededToEnterMoon;
+  }
+
+  bool Settings_MetVictoryRequirements() {
+    u16 remainsCollected = Settings_CountRemainsCollected();
+    return remainsCollected >= gSettingsContext.masksNeededForVictory;
+  }
+
   // With the No Health Refill option on, full health refills from health upgrades and Bombchu
   // Bowling are turned off, and fairies restore 3 hearts Otherwise, they grant a full heal, and the
   // default effect applies (full heal from bottle, 8 hearts on contact)


### PR DESCRIPTION
This change now hooks into the save statement to change the last save location, then warp you back to the South Clock Town Owl from the moon if you do not meet the victory requirements, or you do not have song of time. This should ensure that softlocks don't happen if you are playing no logic or are doing some logic out of order.