### PR TITLE
fix: remove fishing hole passes from item override checks.

### DIFF
--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -92,7 +92,7 @@ namespace rnd {
       // Only override heart pieces and keys
       u32 collectibleType = actor->params & 0xFF;
       // XXX: AFAIK These are correct. Heart piece was checked.
-      if (collectibleType != 0x06 && collectibleType != 0x11 && collectibleType != 0x0A) {
+      if (collectibleType != 0x06 && collectibleType != 0x11) {
         return (ItemOverride_Key){.all = 0};
       }
       retKey.scene = scene;


### PR DESCRIPTION
We don't override any fishing hole passes so we should have the search fail immediately instead.