### PR TITLE
fix: Fix EnPm Hat Drawing, form text in observatory, item drawing in observatory, woodfall key being given errorneously

### DIFF
--- a/code/include/rnd/item_table.h
+++ b/code/include/rnd/item_table.h
@@ -39,7 +39,7 @@ namespace rnd {
   extern "C" ItemRow* rActiveItemRow;
   extern "C" u8 rActiveItemChestType;
   extern "C" u32 rActiveItemTextId;
-  extern "C" u16 rCustomDungeonItemRetrieved;
+  extern "C" u32 rCustomDungeonItemRetrieved;
   u16 ItemTable_ResolveUpgrades(u16 itemId);
   ItemRow* ItemTable_GetItemRow(u16 itemId);
   ItemRow* ItemTable_GetItemRowFromIndex(u8 rowIndex);

--- a/code/include/rnd/models.h
+++ b/code/include/rnd/models.h
@@ -37,6 +37,8 @@ namespace rnd {
   void Model_GetObjectBankIndex(Model* model, game::act::Actor* actor, game::GlobalContext* globalCtx);
   void Model_SetAnim(game::act::SkeletonAnimationModel* model, s16 objectId, u32 objectAnimIndex);
 
+  game::SceneId Model_GetActorScene(game::act::Actor* actor, game::GlobalContext* gctx);
+
   void Model_Init(Model* model, game::GlobalContext* globalCtx);
   void Model_Destroy(Model* model);
   void Model_UpdateAll(game::GlobalContext* globalCtx);

--- a/code/source/asm/fd_hooks.s
+++ b/code/source/asm/fd_hooks.s
@@ -24,25 +24,23 @@ hook_CheckIfLinkIsFD:
 
 .global hook_FixFDObservatoryText
 hook_FixFDObservatoryText:
+  beq 0x30A440
+  bxeq lr @ if we're meeting requirements for first, checks don't bother.
   push {r0-r12, lr}
   bl CheckIfLinkIsFD @ found in link.cpp
   cmp r0, #0x1
   pop {r0-r12,lr}
-  beq 0x30A440
-  cmp r0, #0x2
-  cmpne r0, #0x3
   beq 0x30A440
   bx lr
 
 .global hook_FixFDObservatoryTextTwo
 hook_FixFDObservatoryTextTwo:
+  beq 0x30A4F4
+  bxeq lr
   push {r0-r12, lr}
   bl CheckIfLinkIsFD @ found in link.cpp
   cmp r0, #0x1
   pop {r0-r12,lr}
-  beq 0x30A4F4
-  cmp r0, #0x2
-  cmpne r0, #0x3
   beq 0x30A4F4
   bx lr
 

--- a/code/source/rnd/gfx.cpp
+++ b/code/source/rnd/gfx.cpp
@@ -743,7 +743,7 @@ namespace rnd {
 
       // Keep updating while in the in-game menu
       Draw_ClearBackbuffer();
-      Draw_ClearFramebuffer();
+      // Draw_ClearFramebuffer();
 
       // Continue counting up play time while in the in-game menu
       Gfx_UpdatePlayTime();

--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -32,7 +32,7 @@ namespace rnd {
   u32 rActiveItemTextId = 0;
   u32 rActiveItemObjectId = 0;
   u16 rStoredTextId = 0;
-  u16 rCustomDungeonItemRetrieved = 0;
+  u32 rCustomDungeonItemRetrieved = 0;
   u8 rActiveItemChestType = 0;
   bool isItemOverrideActive = false;
 

--- a/code/source/rnd/item_table.cpp
+++ b/code/source/rnd/item_table.cpp
@@ -553,7 +553,7 @@ namespace rnd {
                         (rnd::upgradeFunc)ItemUpgrade_None, ItemEffect_GiveSkulltula, (s16)1, (s16)-1,
                         1.00f),  // Gold Skulltula - Ocean
 
-      [0x6E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SeaHorse, 0x006E, 0x01E9,
+      [0x6E] = ITEM_ROW((u32)GetItemID::GI_NUTS_30, ChestType::WOODEN_BIG, (u8)game::ItemId::SeaHorse, 0x006E, 0x01F0,
                         0x00, (s8)0xFF, (s8)0xFF, (s8)0xFF, (s8)0xFF, DrawGraphicItemID::DI_BOTTLE_SEAHORSE,
                         (rnd::upgradeFunc)ItemUpgrade_RefillBottle, ItemEffect_None, (s16)-1, (s16)-1,
                         1.00f),  // Bottle With Sea Horse - Gold Dust Object

--- a/code/source/rnd/models.cpp
+++ b/code/source/rnd/models.cpp
@@ -95,6 +95,20 @@ namespace rnd {
     util::GetPointer<void(void*, void*, void*)>(0x19A360)(dst, src, vec);
   }
 
+  game::SceneId Model_GetActorScene(game::act::Actor* actor, game::GlobalContext* gctx) {
+    // Some models will tend to travel around, like Postman and Kafei.
+    // Their overrides do not, so we need to change the scene for the
+    // key lookup.
+    switch (actor->id) {
+    case game::act::Id::NpcEnPm:
+      return game::SceneId::EastClockTown;
+    case game::act::Id::ObjMoonStone:
+      return game::SceneId::TerminaField;
+    default:
+      return gctx->scene;
+    }
+  }
+
   void Model_SetMatrix(Model* model) {
     // Init scale matrix
     z3d_nn_math_MTX44 scaleMtx = {0};
@@ -250,7 +264,8 @@ namespace rnd {
   }
 
   void Model_InfoLookup(Model* model, game::act::Actor* actor, game::GlobalContext* globalCtx, u16 baseItemId) {
-    ItemOverride override = ItemOverride_Lookup(actor, (u16)globalCtx->scene, baseItemId);
+    u16 scene = (u16)Model_GetActorScene(actor, globalCtx);
+    ItemOverride override = ItemOverride_Lookup(actor, scene, baseItemId);
 
     if (override.key.all != 0) {
       if (override.key.type == ItemOverride_Type::OVR_SKULL && ItemOverride_IsSkullCollected(actor, globalCtx->scene) &&


### PR DESCRIPTION
nit: Include the actual sea horse in bottle model instead of gold dust.
fix: Adjust clearing frame buffer to  make sure menu doesn't flash every second.