### PR TITLE
Include check for looks like item ID, if one does not exist, then use…

### DIFF
--- a/code/source/rnd/item_override.cpp
+++ b/code/source/rnd/item_override.cpp
@@ -573,7 +573,8 @@ namespace rnd {
         return 0x1D;
     }
     // No override, use the base item.
-    return override.value.looksLikeItemId;
+    return override.value.looksLikeItemId == 0xFF || override.value.looksLikeItemId == 0x00 ?
+        override.value.getItemId : override.value.looksLikeItemId;
   }
 
   bool ItemOverride_IsItemObtainedOrEmptyBottle(ItemOverride override) {


### PR DESCRIPTION
… the base item.