### PR TITLE
feat: Update in game spoiler to use full circle pad pro support.

### DIFF
--- a/code/include/hid.h
+++ b/code/include/hid.h
@@ -80,6 +80,15 @@ typedef struct {
 } hid_mem_t;
 
 typedef struct {
+  int16_t cp_x, cp_y;
+  int16_t cstick_x, cstick_y;
+  uint32_t held;
+  uint32_t released;
+  uint8_t cstick_active;
+  uint8_t cppConnected;
+} ir_pad_state_t;
+
+typedef struct {
   uint32_t field_00;
   struct hid_pad_t* hid_pad;
   uint32_t field_08;
@@ -97,6 +106,12 @@ typedef struct {
   uint32_t bool_44;
 } hid_ctx_t;
 
+#define real_ir_pad_addr 0x007C1490
+#define real_ir_pad (*(volatile ir_pad_state_t*)real_ir_pad_addr)
+
+// ZL | ZR | C-stick direction bits — the only bits raw HID can never supply.
+#define IR_PAD_EXTRA_MASK 0x0F00C000
+
 #define BUTTON_A (1 << 0)
 #define BUTTON_B (1 << 1)
 #define BUTTON_SELECT (1 << 2)
@@ -109,6 +124,12 @@ typedef struct {
 #define BUTTON_L1 (1 << 9)
 #define BUTTON_X (1 << 10)
 #define BUTTON_Y (1 << 11)
+#define BUTTON_ZL (1 << 14)
+#define BUTTON_ZR (1 << 15)
+#define CSTICK_RIGHT (1 << 24)
+#define CSTICK_LEFT (1 << 25)
+#define CSTICK_UP (1 << 26)
+#define CSTICK_DOWN (1 << 27)
 #define CPAD_RIGHT (1 << 28)
 #define CPAD_LEFT (1 << 29)
 #define CPAD_UP (1 << 30)

--- a/code/include/rnd/draw.h
+++ b/code/include/rnd/draw.h
@@ -126,6 +126,7 @@ void Draw_ClearBackbuffer(void);
 void Draw_CopyBackBuffer(void);
 void Draw_FlushFramebuffer(void);
 void Draw_FlushFramebufferTop(void);
+void Draw_SetTopScreenDirty(void);
 
 struct FramebufferAddress {
   u8* a;

--- a/code/source/rnd/draw.cpp
+++ b/code/source/rnd/draw.cpp
@@ -361,3 +361,17 @@ void Draw_FlushFramebufferTop(void) {
   svcFlushProcessDataCache(CUR_PROCESS_HANDLE, u32(FRAMEBUFFER[4]), FB_TOP_SIZE);
   svcFlushProcessDataCache(CUR_PROCESS_HANDLE, u32(FRAMEBUFFER[5]), FB_TOP_SIZE);
 }
+
+void Draw_SetTopScreenDirty(void) {
+  // Due to a new feature in Azahar 2126, we need to refresh the top screen
+  // with a dirty bit in order to avoid frame generation ignoring the 
+  // custom menu.
+  u32 frameBufTopScreenAddr = *rnd::util::GetPointer<u32>(0x64E5DC);
+  if (frameBufTopScreenAddr == 0)
+    return;
+  volatile u32* fbInfo = (volatile u32*)frameBufTopScreenAddr;
+  u32 header = fbInfo[0];
+  u32 newIdx = (header & 1) ^ 1;
+
+  fbInfo[0] = (header & 0xFFFF0000) | 0x100 | newIdx;
+}

--- a/code/source/rnd/draw.cpp
+++ b/code/source/rnd/draw.cpp
@@ -364,7 +364,7 @@ void Draw_FlushFramebufferTop(void) {
 
 void Draw_SetTopScreenDirty(void) {
   // Due to a new feature in Azahar 2126, we need to refresh the top screen
-  // with a dirty bit in order to avoid frame generation ignoring the 
+  // with a dirty bit in order to avoid frame generation ignoring the
   // custom menu.
   u32 frameBufTopScreenAddr = *rnd::util::GetPointer<u32>(0x64E5DC);
   if (frameBufTopScreenAddr == 0)

--- a/code/source/rnd/gfx.cpp
+++ b/code/source/rnd/gfx.cpp
@@ -762,7 +762,6 @@ namespace rnd {
         Draw_FlushFramebuffer();
       else
         Draw_SetTopScreenDirty();
-        
 
       pressed = Input_WaitWithTimeout(1000, closingButton);
 

--- a/code/source/rnd/gfx.cpp
+++ b/code/source/rnd/gfx.cpp
@@ -625,8 +625,12 @@ namespace rnd {
   static void Gfx_ShowMenu(void) {
     pressed = 0;
     Draw_ClearFramebuffer();
+    Draw_ClearFramebuffer();
     if (!playingOnCitra)
       Draw_FlushFramebuffer();
+    else
+      Draw_SetTopScreenDirty();
+
     do {
       // End the loop if the system has gone to sleep, so the game can properly respond
       if (isAsleep) {
@@ -719,6 +723,8 @@ namespace rnd {
           Draw_CopyBackBuffer();
           if (!playingOnCitra)
             Draw_FlushFramebuffer();
+          else
+            Draw_SetTopScreenDirty();
           break;
         } else if (pressed & BUTTON_R1) {
           showingLegend = false;
@@ -754,6 +760,10 @@ namespace rnd {
       Draw_CopyBackBuffer();
       if (!playingOnCitra)
         Draw_FlushFramebuffer();
+      else
+        Draw_SetTopScreenDirty();
+        
+
       pressed = Input_WaitWithTimeout(1000, closingButton);
 
     } while (true);

--- a/code/source/rnd/input.cpp
+++ b/code/source/rnd/input.cpp
@@ -38,7 +38,6 @@ namespace rnd {
 
   InputContext rInputCtx = {};
 
-
   // Needed for menus external to the game for spoiler logs.
   void Input_Update() {
     rInputCtx.cur.val = MergeIrPad(real_hid->pad.pads[real_hid->pad.index].curr.val);

--- a/code/source/rnd/input.cpp
+++ b/code/source/rnd/input.cpp
@@ -8,17 +8,40 @@ extern "C" {
 #include <3ds/svc.h>
 }
 namespace rnd {
+  static u32 MergeIrPad(u32 pad) {
+    u8 conn = *util::GetPointer<u8>(0x7C14A5);
+    u32 extra = *util::GetPointer<u32>(0x7C1498) & 0x0F00C000;
+    if (conn)
+      pad |= extra;
+
+    // Circle pad has an input state but is never read on console
+    // So let's set a threshold for the circle pad.
+    const s16 threshold = 40;
+    cp_t cp = real_hid->pad.pads[real_hid->pad.index].cp;
+    if (cp.x > threshold)
+      pad |= CPAD_RIGHT;
+    if (cp.x < -threshold)
+      pad |= CPAD_LEFT;
+    if (cp.y > threshold)
+      pad |= CPAD_UP;
+    if (cp.y < -threshold)
+      pad |= CPAD_DOWN;
+    return pad;
+  }
+
   u32 GetCurrentPadState(void) {
     u32 hid_shared_mem = *(u32*)(0x007b2d34);
-    return *(volatile u32*)(hid_shared_mem + 0x1C);
+    return MergeIrPad(*(volatile u32*)(hid_shared_mem + 0x1C));
   }
+
 #define HID_PAD (GetCurrentPadState())
 
   InputContext rInputCtx = {};
 
+
   // Needed for menus external to the game for spoiler logs.
   void Input_Update() {
-    rInputCtx.cur.val = real_hid->pad.pads[real_hid->pad.index].curr.val;
+    rInputCtx.cur.val = MergeIrPad(real_hid->pad.pads[real_hid->pad.index].curr.val);
     rInputCtx.pressed.val = (rInputCtx.cur.val) & (~rInputCtx.old.val);
     rInputCtx.up.val = (~rInputCtx.cur.val) & (rInputCtx.old.val);
     rInputCtx.old.val = rInputCtx.cur.val;
@@ -27,7 +50,7 @@ namespace rnd {
 
   u32 buttonCheck(u32 key) {
     for (u32 i = 0x26000; i > 0; i--) {
-      if (key != real_hid->pad.pads[real_hid->pad.index].curr.val)
+      if (key != MergeIrPad(real_hid->pad.pads[real_hid->pad.index].curr.val))
         return 0;
     }
     return 1;


### PR DESCRIPTION
feat: Adjust circle pad to use thresholds to allow scrolling with circle pad.

fix: Include a dirty bit rewrite to ensure Azahar redraws the spoiler menu in new releases..